### PR TITLE
fix the router

### DIFF
--- a/app/src/components/header.tsx
+++ b/app/src/components/header.tsx
@@ -9,7 +9,6 @@ import {
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { BenchmarkChartData, Variation } from "@/types/chart-data";
-import { DATE_YEAR, DATE_MONTH, DATE_DAY } from "@/constants";
 
 interface HeaderProps {
   chartData: BenchmarkChartData | null;
@@ -34,11 +33,6 @@ export const Header = ({ chartData }: HeaderProps) => {
                 </span>
               )}
             </h1>
-            {chartData && (
-              <p className="text-sm text-muted-foreground mt-1 font-medium">
-                Results from {DATE_YEAR}-{DATE_MONTH}-{DATE_DAY}
-              </p>
-            )}
           </div>
 
           {chartData && (

--- a/app/src/constants/index.ts
+++ b/app/src/constants/index.ts
@@ -1,13 +1,4 @@
-
-export const TODAY = new Date();
-
-export const DATE_YEAR = TODAY.getFullYear();
-
-export const DATE_MONTH = String(TODAY.getMonth() + 1).padStart(2, "0");
-
-export const DATE_DAY = String(TODAY.getDate()).padStart(2, "0");
-
-export const CHART_DATA_URL = `/benchmarks/${DATE_YEAR}-${DATE_MONTH}-${DATE_DAY}/chart-data.json`;
+export const CHART_DATA_URL = `/benchmarks/latest/chart-data.json`;
 
 export const CHART_DEFAULTS = {
   HEIGHT: 300,

--- a/app/src/hooks/use-package-count-data.ts
+++ b/app/src/hooks/use-package-count-data.ts
@@ -5,7 +5,6 @@ import type {
   PackageCountData,
   PackageCountTableRow,
 } from "@/types/chart-data";
-import { DATE_YEAR, DATE_MONTH, DATE_DAY } from "@/constants";
 
 interface UsePackageCountDataReturn {
   packageCountData: PackageCountTableRow[];
@@ -34,7 +33,7 @@ export const usePackageCountData = (
 
       for (const fixture of fixtures) {
         try {
-          const url = `/benchmarks/${DATE_YEAR}-${DATE_MONTH}-${DATE_DAY}/${fixture}-${variation}-package-count.json`;
+          const url = `/benchmarks/latest/${fixture}-${variation}-package-count.json`;
           const response = await fetch(url);
 
           if (response.ok) {

--- a/app/src/routes.tsx
+++ b/app/src/routes.tsx
@@ -16,8 +16,6 @@ export const routes: RouteObject[] = [
   },
 ];
 
-const router = createHashRouter(routes, {
-  basename: "/benchmarks",
-});
+const router = createHashRouter(routes);
 
 export const Router = () => <RouterProvider router={router} />;


### PR DESCRIPTION
### Overview
Using a `basename` with the hashrouter is problematic in this case because the deployed url is `https://vltpkg.github.io/benchmarks/`, however with the `basename` set to `/benchmarks` the actual url is `https://vltpkg.github.io/benchmarks/#/benchmarks/` since the `hashrouter` will ignore everything up until the `#`

It also fixes the issue with loading the data that is prefixed with the date, instead just loads the chart data prefixed with `/latest` and removes the `new Date()` helpers in the `constants` dir.

This will work ontop of #19

### Solution
Remove the `basename` from the `createHashRouter` call in `routes.tsx`
Update the data fetching to use the `/latest` prefix instead of the date prefix.
