### PR TITLE
updates the routing

### DIFF
--- a/app/src/constants/index.ts
+++ b/app/src/constants/index.ts
@@ -1,4 +1,4 @@
-export const CHART_DATA_URL = `/benchmarks/latest/chart-data.json`;
+export const CHART_DATA_URL = `/latest/chart-data.json`;
 
 export const CHART_DEFAULTS = {
   HEIGHT: 300,

--- a/app/src/hooks/use-package-count-data.ts
+++ b/app/src/hooks/use-package-count-data.ts
@@ -33,7 +33,7 @@ export const usePackageCountData = (
 
       for (const fixture of fixtures) {
         try {
-          const url = `/benchmarks/latest/${fixture}-${variation}-package-count.json`;
+          const url = `/latest/${fixture}-${variation}-package-count.json`;
           const response = await fetch(url);
 
           if (response.ok) {

--- a/app/src/routes.tsx
+++ b/app/src/routes.tsx
@@ -1,4 +1,4 @@
-import { RouterProvider, createHashRouter } from "react-router";
+import { RouterProvider, createBrowserRouter } from "react-router";
 import App from "@/app";
 import { VariationPage } from "@/components/variation";
 import type { RouteObject } from "react-router";
@@ -16,6 +16,6 @@ export const routes: RouteObject[] = [
   },
 ];
 
-const router = createHashRouter(routes);
+const router = createBrowserRouter(routes);
 
 export const Router = () => <RouterProvider router={router} />;

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -4,7 +4,7 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  base: "/benchmarks/",
+  base: "/",
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
### Changelog
- retires the `createHashRouter` in preference of `createBrowserRouter`
- updates the `base` in `vite.config.ts` to root `/` instead of
  `/benchmarks/` (due to the cname)
- updates the locations of `chart-data` and fixture variants
