### PR TITLE
fix render for a failed run

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -184,6 +184,16 @@ jobs:
                           console.log(`Cleaned ${fixture}-${variation} (result ${i}): ${times.length - cleanTimes.length} failed runs removed, ${cleanTimes.length} valid runs remaining`);
                         } else {
                           console.warn(`All runs failed for ${fixture}-${variation} (result ${i})`);
+                          // reset all values to 0
+                          result.times = [0];
+                          result.exit_codes = [1];
+                          result.mean = 0;
+                          result.stddev = 0;
+                          result.median = 0;
+                          result.min = 0;
+                          result.max = 0;
+                          result.user = 0;
+                          result.system = 0;
                         }
                       } else {
                         console.warn(`Invalid times/exit_codes arrays for ${fixture}-${variation} (result ${i})`);

--- a/README.md
+++ b/README.md
@@ -166,6 +166,30 @@ Each run creates a new dated html file with its results, making it easy to track
 4. Push to the branch
 5. Create a Pull Request
 
+## Local debugging
+
+You can debug the result process scripts and the web app locally by using data
+from previous [GitHub Action runs of the Package Manager Benchmarks workflow](https://github.com/vltpkg/benchmarks/actions/workflows/benchmark.yaml).
+
+Those can be individually downloaded and their `benchmarks.json` files renamed
+to a `results/<date>/<fixture>-<variation>.json` file, where `<date>` needs to
+match a folder name in the `results` folder in a `YYYY-MM-DD` pattern and
+`<fixture>` is one of the known project type fixtures and `<variation>` is one
+of the known variations (e.g. `clean`, `cache`, `lockfile`, etc).
+
+You may test the chart data generation script locally by running: 
+
+```sh
+node scripts/generate-chart.js <date>
+```
+
+Make sure you have a `results/<date>` directory with valid benchmark
+result JSON files in it.
+
+After a succesful run, test the web app rendering the chart data locally
+by copying the result `results/<date>/chart-data.json` file to the
+web app folder in a `latest/` folder, e.g: `app/latest/chart-data.json`
+
 ## License
 
 This project is licensed under the BSD-2-Clause-Patent License - see the LICENSE file for details.

--- a/scripts/generate-chart.js
+++ b/scripts/generate-chart.js
@@ -1,3 +1,9 @@
+// test it locally like this: `node scripts/generate-chart.js 2025-10-06`
+// make sure you have a results/2025-10-06 directory with valid benchmark
+// result JSON files (e.g: results/2025-10-06/next-lockfile.json)
+// after a succesful run, test the web app rendering the chart data locally
+// by copying the result `results/2025-10-06/chart-data.json` file to the
+// web app folder in a `latest/` folder, e.g: app/latest/chart-data.json
 import fs from "fs";
 import path from "path";
 


### PR DESCRIPTION
When a package manager failed all its runs for a given fixture+variation combination, then we should consider all result values invalid for that scenario and avoid rendering data for that package manager in the resulting chart.