### PR TITLE
Registry per-package normalization + fix colored tooltip boxes

### DIFF
--- a/app/src/components/ui/chart.tsx
+++ b/app/src/components/ui/chart.tsx
@@ -291,10 +291,23 @@ function ChartTooltipContent({
           const itemConfig = getPayloadConfigFromPayload(config, item, key);
           const isDnf = isDnfPayload(item);
           const dnfIndicatorColor = isDnf ? getDnfIndicatorColor(item) : null;
+          // Resolve the indicator color. For DNF entries, getDnfIndicatorColor
+          // reads the hex color from `${dataKey}_fill` in the payload. For
+          // non-DNF entries, we also try `${dataKey}_fill` as a reliable
+          // fallback since item.color / item.payload?.fill may be a pattern
+          // URL when <Cell> overrides the fill for SVG stripe patterns.
+          const payloadFillKey =
+            typeof (item.dataKey ?? item.name) === "string"
+              ? `${item.dataKey ?? item.name}_fill`
+              : undefined;
+          const payloadFillColor =
+            payloadFillKey && item.payload
+              ? (item.payload[payloadFillKey] as string | undefined)
+              : undefined;
           const indicatorColor =
             dnfIndicatorColor ||
             color ||
-            (item.payload?.fill as string) ||
+            payloadFillColor ||
             item.color;
 
           return (

--- a/app/src/components/variation/chart.tsx
+++ b/app/src/components/variation/chart.tsx
@@ -108,8 +108,21 @@ const HorizontalBarTooltipContent = ({
             item.payload?.dnf === true ||
             (typeof item.dataKey === "string" &&
               item.payload?.[`${item.dataKey}_dnf`] === true);
-          const color =
-            (item.payload?.dnfColor as string) || item.fill || item.color;
+          // Resolve color for the indicator box. For DNF entries, use the
+          // explicit dnfColor (hex) from the data row. For non-DNF entries,
+          // use the data row's fill (a hex color for normal bars). We prefer
+          // item.payload?.dnfColor / item.payload?.fill over item.fill /
+          // item.color because Recharts derives those from the <Bar> component
+          // (which has no fill prop), NOT from the <Cell> fill override.
+          const color = isDnf
+            ? (item.payload?.dnfColor as string) ||
+              (item.payload?.fill as string) ||
+              item.fill ||
+              item.color
+            : (item.payload?.dnfColor as string) ||
+              (item.payload?.fill as string) ||
+              item.fill ||
+              item.color;
 
           return (
             <div key={index} className="flex items-center gap-2">
@@ -663,6 +676,7 @@ export const VariationChart = ({
                       ? getDnfPatternFill(fixtureId, pm)
                       : getColor(pm),
                     dnf: isDnf,
+                    dnfColor: getColor(pm),
                     pm,
                   };
                 })

--- a/app/src/components/variation/index.tsx
+++ b/app/src/components/variation/index.tsx
@@ -147,6 +147,18 @@ export const VariationPage = () => {
   const isTaskExecution = isTaskExecutionVariation(variation as string);
   const isRegistry = isRegistryVariation(variation as string);
 
+  // For registry variations, check if per-package data actually contains
+  // count fields (indicating package counts were collected). Without counts
+  // the per-package data is identical to total time — don't show the section.
+  const hasRegistryPerPackageData =
+    isRegistry &&
+    filteredPerPackageVariationData.some((fixture) =>
+      packageManagers.some((pm) => {
+        const countKey = `${pm}_count` as keyof FixtureResult;
+        return typeof fixture[countKey] === "number";
+      }),
+    );
+
   // Dynamic titles and section IDs based on variation type
   const titles = isTaskExecution
     ? {
@@ -161,8 +173,8 @@ export const VariationPage = () => {
       ? {
           totalChart: "Registry Install Time by Fixture",
           totalTable: "Registry Install Time Data",
-          perPackageChart: "Registry Install Time by Fixture",
-          perPackageTable: "Registry Install Time Data",
+          perPackageChart: "Registry Per Package Install Time by Fixture",
+          perPackageTable: "Registry Per Package Install Time Data",
           packageCountTable: "Package Count Data",
           processCountTable: "Spawned Processes Data",
         }
@@ -211,8 +223,8 @@ export const VariationPage = () => {
         />
       </div>
 
-      {/* 1. Per-package fixture charts - only show for package management tests */}
-      {!isTaskExecution && !isRegistry && (
+      {/* 1. Per-package fixture charts - show for PM tests and registry when data available */}
+      {(!isTaskExecution && !isRegistry) || hasRegistryPerPackageData ? (
         <div id={sectionIds.perPackageChart}>
           <VariationChart
             title={titles.perPackageChart}
@@ -224,11 +236,11 @@ export const VariationPage = () => {
             currentVariation={variation as string}
           />
         </div>
-      )}
+      ) : null}
 
       <div className="space-y-8">
-        {/* 2. Per-package fixture data table - only show for package management tests */}
-        {!isTaskExecution && !isRegistry && (
+        {/* 2. Per-package fixture data table - show for PM tests and registry when data available */}
+        {(!isTaskExecution && !isRegistry) || hasRegistryPerPackageData ? (
           <div id={sectionIds.perPackageTable}>
             <VariationTable
               title={titles.perPackageTable}
@@ -239,7 +251,7 @@ export const VariationPage = () => {
               currentVariation={variation as string}
             />
           </div>
-        )}
+        ) : null}
 
         {/* 3. Package count data table */}
         {packageCountLoading ? (

--- a/app/src/hooks/use-chart-data.ts
+++ b/app/src/hooks/use-chart-data.ts
@@ -102,6 +102,13 @@ export const useChartData = (): UseChartDataReturn => {
     perPackageCountChartData: applyDnfFallbacksToDataSet(
       data.perPackageCountChartData,
     ),
+    ...(data.registryPerPackageCountChartData
+      ? {
+          registryPerPackageCountChartData: applyDnfFallbacksToDataSet(
+            data.registryPerPackageCountChartData,
+          ),
+        }
+      : {}),
   });
 
   const fetchChartData = async () => {
@@ -154,6 +161,8 @@ export const useChartData = (): UseChartDataReturn => {
 
       // Merge registry chart data into main chart data if present
       const registryData = normalizedChartData.registryChartData;
+      const registryPerPackageData =
+        normalizedChartData.registryPerPackageCountChartData;
       const registryVariations: Variation[] = registryData?.variations ?? [];
       const allVariations: Variation[] = [
         ...variations,
@@ -172,7 +181,13 @@ export const useChartData = (): UseChartDataReturn => {
       if (registryData) {
         for (const [variation, data] of Object.entries(registryData.data)) {
           mergedData[variation as Variation] = data;
-          mergedPerPackageData[variation as Variation] = data;
+          // For per-package data, use registryPerPackageCountChartData when
+          // available (has normalized ms/pkg values). Falls back to the total
+          // time data for older chart-data.json files that lack it.
+          const perPkgVariationData =
+            registryPerPackageData?.data?.[variation as Variation];
+          mergedPerPackageData[variation as Variation] =
+            perPkgVariationData ?? data;
         }
       }
 

--- a/app/src/hooks/use-history-data.ts
+++ b/app/src/hooks/use-history-data.ts
@@ -85,6 +85,11 @@ interface ChartDataResponse {
     data: FixtureDataSet;
     packageManagers: string[];
   };
+  registryPerPackageCountChartData?: {
+    variations: string[];
+    data: FixtureDataSet;
+    packageManagers: string[];
+  };
 }
 
 /**
@@ -109,9 +114,14 @@ function extractDayData(
     response.perPackageCountChartData?.data ?? response.chartData.data;
   extractFromDataSet(pmSource, result);
 
-  // Process registry chart data (separate data set, always total time)
-  if (response.registryChartData?.data) {
-    extractFromDataSet(response.registryChartData.data, result);
+  // Process registry chart data. Use registryPerPackageCountChartData when
+  // available (normalized ms/pkg values); fall back to total-time
+  // registryChartData for older files that lack per-package registry data.
+  const registrySource =
+    response.registryPerPackageCountChartData?.data ??
+    response.registryChartData?.data;
+  if (registrySource) {
+    extractFromDataSet(registrySource, result);
   }
 
   return result;

--- a/app/src/types/chart-data.ts
+++ b/app/src/types/chart-data.ts
@@ -166,6 +166,7 @@ export interface BenchmarkChartData {
   chartData: ChartDataSet;
   perPackageCountChartData: ChartDataSet;
   registryChartData?: ChartDataSet;
+  registryPerPackageCountChartData?: ChartDataSet;
   versions?: PackageManagerVersions;
 }
 

--- a/scripts/collect-package-count.js
+++ b/scripts/collect-package-count.js
@@ -18,7 +18,7 @@ try {
   result = {};
 }
 
-// Define the possible count files and their corresponding package manager names
+// Define the possible count files and their corresponding package manager / registry names
 const countFiles = [
   { filename: 'npm-count.txt', pmName: 'npm' },
   { filename: 'yarn-count.txt', pmName: 'yarn' },
@@ -28,7 +28,11 @@ const countFiles = [
   { filename: 'pnpm11-count.txt', pmName: 'pnpm11' },
   { filename: 'vlt-count.txt', pmName: 'vlt' },
   { filename: 'bun-count.txt', pmName: 'bun' },
-  { filename: 'deno-count.txt', pmName: 'deno' }
+  { filename: 'deno-count.txt', pmName: 'deno' },
+  // Registry names (for registry benchmark variations)
+  { filename: 'aws-count.txt', pmName: 'aws' },
+  { filename: 'cloudsmith-count.txt', pmName: 'cloudsmith' },
+  { filename: 'github-count.txt', pmName: 'github' },
 ];
 
 let pmName = null;

--- a/scripts/generate-chart.js
+++ b/scripts/generate-chart.js
@@ -248,7 +248,7 @@ function generateChartData(option = {}) {
 }
 
 // Generate chart data for registry benchmarks
-function generateRegistryChartData() {
+function generateRegistryChartData(option = {}) {
   const fixtures = ["next", "astro", "svelte", "vue", "large", "babylon"];
   const variations = ["registry-clean", "registry-lockfile"];
   const registries = Object.keys(REGISTRY_COLORS);
@@ -267,6 +267,33 @@ function generateRegistryChartData() {
       }
 
       const results = readResults(file);
+      const packageCounts = {};
+
+      // If perPackageCount is enabled, try to load the package count for this fixture/variation
+      if (option.perPackageCount) {
+        const countFile = path.resolve(
+          RESULTS_DIR,
+          `${fixture}-${variation}-package-count.json`,
+        );
+        if (fs.existsSync(countFile)) {
+          try {
+            const countData = JSON.parse(fs.readFileSync(countFile, "utf8"));
+            registries.forEach((reg) => {
+              if (
+                countData &&
+                typeof countData === "object" &&
+                countData[reg] &&
+                typeof countData[reg].count === "number"
+              ) {
+                packageCounts[reg] = countData[reg].count;
+              }
+            });
+          } catch (e) {
+            // Ignore parse errors, fallback to undefined counts
+          }
+        }
+      }
+
       const pmEntries = {};
       const validValues = [];
 
@@ -276,10 +303,21 @@ function generateRegistryChartData() {
 
         const didFail =
           registryResult.failed || !Number.isFinite(registryResult.mean);
+        const count = packageCounts[registry];
         let value =
           typeof registryResult.mean === "number"
             ? registryResult.mean
             : undefined;
+
+        if (
+          !didFail &&
+          option.perPackageCount &&
+          typeof count === "number" &&
+          count > 0 &&
+          typeof value === "number"
+        ) {
+          value = (value / count) * 1000;
+        }
 
         if (!didFail && typeof value === "number") {
           validValues.push(value);
@@ -289,6 +327,7 @@ function generateRegistryChartData() {
           didFail,
           value: didFail ? undefined : value,
           stddev: didFail ? undefined : registryResult.stddev,
+          count,
         };
       });
 
@@ -311,6 +350,9 @@ function generateRegistryChartData() {
 
       Object.entries(entry.pmEntries).forEach(([registry, regEntry]) => {
         fixtureResults[`${registry}_fill`] = REGISTRY_COLORS[registry];
+        if (regEntry.count !== undefined) {
+          fixtureResults[`${registry}_count`] = regEntry.count;
+        }
 
         if (regEntry.didFail) {
           fixtureResults[`${registry}_dnf`] = true;
@@ -377,6 +419,9 @@ const dumpChartData = () => {
   const chartData = generateChartData();
   const perPackageCountChartData = generateChartData({ perPackageCount: true });
   const registryChartData = generateRegistryChartData();
+  const registryPerPackageCountChartData = generateRegistryChartData({
+    perPackageCount: true,
+  });
   const versions = loadPackageManagersVersionData();
 
   const results = {
@@ -399,6 +444,12 @@ const dumpChartData = () => {
       data: registryChartData.data,
       packageManagers: registryChartData.packageManagers,
       colors: registryChartData.colors,
+    },
+    registryPerPackageCountChartData: {
+      variations: registryPerPackageCountChartData.variations,
+      data: registryPerPackageCountChartData.data,
+      packageManagers: registryPerPackageCountChartData.packageManagers,
+      colors: registryPerPackageCountChartData.colors,
     },
     versions,
   };

--- a/scripts/process-results.sh
+++ b/scripts/process-results.sh
@@ -138,6 +138,14 @@ for fixture in next astro svelte vue large babylon; do
         else
             echo "Warning: No results found for $fixture & $variation"
         fi
+
+        if package_count_file=$(resolve_result_path "$fixture" "$variation" "package-count.json"); then
+            print_package_count "$package_count_file" "$fixture" "$variation"
+            cp "$package_count_file" "results/$DATE/$fixture-$variation-package-count.json"
+            cp "$package_count_file" "results/latest/$fixture-$variation-package-count.json"
+        else
+            echo "Warning: No package count found for $fixture & $variation (registry)"
+        fi
     done
 done
 

--- a/scripts/registry-package-count.sh
+++ b/scripts/registry-package-count.sh
@@ -1,0 +1,40 @@
+# Exit on error
+set -Eeuxo pipefail
+
+if [ -z "${1:-}" ]; then
+  echo "Error: A results folder path is required"
+  exit 1
+else
+  BENCH_PACKAGE_COUNT_FOLDER="$1"
+fi
+
+if [ -z "${2:-}" ]; then
+  echo "Error: A registry name is required"
+  exit 1
+else
+  BENCH_REGISTRY_NAME="$2"
+fi
+
+# If the node_modules directory exists, count the number of packages
+if [ -d "node_modules" ]; then
+  BENCH_PACKAGE_COUNT=$(
+    find node_modules -name package.json -type f \
+    | grep -E 'node_modules/([a-zA-Z0-9_-]+)/package\.json$|node_modules/@[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+/package\.json$' \
+    | sort -u \
+    | wc -l \
+    | xargs
+  ) || true
+else
+  echo "Warning: node_modules directory does not exist"
+  exit 0
+fi
+
+# if we couldn't determine the package count, then just exit
+if [ -z "${BENCH_PACKAGE_COUNT+x}" ] || [ "$BENCH_PACKAGE_COUNT" = "0" ]; then
+  echo "Warning: Could not determine the package count"
+  exit 0
+fi
+
+# Create the results directory if it doesn't exist and write the count file
+mkdir -p "$BENCH_PACKAGE_COUNT_FOLDER"
+echo "$BENCH_PACKAGE_COUNT" >> "$BENCH_PACKAGE_COUNT_FOLDER/$BENCH_REGISTRY_NAME-count.txt"

--- a/scripts/registry/common.sh
+++ b/scripts/registry/common.sh
@@ -92,13 +92,21 @@ BENCH_SETUP_REGISTRY_GITHUB="npm config set registry \"$BENCH_REGISTRY_GITHUB_UR
 
 # Registry verification helper runs in hyperfine --conclude (untimed, after each run).
 BENCH_VERIFY_REGISTRY="npm config get registry && ((grep -m3 '\"resolved\"' package-lock.json 2>/dev/null | sed 's/^[[:space:]]*//') || echo 'no lockfile yet') && echo ''"
+# Package count collection: after each run, count installed packages and tag
+# them with the registry name (e.g. npm-count.txt, vlt-count.txt, aws-count.txt).
+# This uses registry-package-count.sh which writes <registry>-count.txt files.
+BENCH_COLLECT_PKG_COUNT_NPM="bash $BENCH_SCRIPTS/registry-package-count.sh $BENCH_OUTPUT_FOLDER npm"
+BENCH_COLLECT_PKG_COUNT_VLT="bash $BENCH_SCRIPTS/registry-package-count.sh $BENCH_OUTPUT_FOLDER vlt"
+BENCH_COLLECT_PKG_COUNT_AWS="bash $BENCH_SCRIPTS/registry-package-count.sh $BENCH_OUTPUT_FOLDER aws"
+BENCH_COLLECT_PKG_COUNT_CLOUDSMITH="bash $BENCH_SCRIPTS/registry-package-count.sh $BENCH_OUTPUT_FOLDER cloudsmith"
+BENCH_COLLECT_PKG_COUNT_GITHUB="bash $BENCH_SCRIPTS/registry-package-count.sh $BENCH_OUTPUT_FOLDER github"
 # hyperfine does not provide HYPERFINE_ITERATION in conclude hooks, so these
 # write to per-registry verification logs instead of per-iteration logs.
-BENCH_CONCLUDE_NPM="{ $BENCH_VERIFY_REGISTRY; } >> $BENCH_OUTPUT_FOLDER/npm-verify.log 2>&1"
-BENCH_CONCLUDE_VLT_REG="{ $BENCH_VERIFY_REGISTRY; } >> $BENCH_OUTPUT_FOLDER/vlt-verify.log 2>&1"
-BENCH_CONCLUDE_AWS="{ $BENCH_VERIFY_REGISTRY; } >> $BENCH_OUTPUT_FOLDER/aws-verify.log 2>&1"
-BENCH_CONCLUDE_CLOUDSMITH="{ $BENCH_VERIFY_REGISTRY; } >> $BENCH_OUTPUT_FOLDER/cloudsmith-verify.log 2>&1"
-BENCH_CONCLUDE_GITHUB="{ $BENCH_VERIFY_REGISTRY; } >> $BENCH_OUTPUT_FOLDER/github-verify.log 2>&1"
+BENCH_CONCLUDE_NPM="{ $BENCH_VERIFY_REGISTRY; } >> $BENCH_OUTPUT_FOLDER/npm-verify.log 2>&1; $BENCH_COLLECT_PKG_COUNT_NPM"
+BENCH_CONCLUDE_VLT_REG="{ $BENCH_VERIFY_REGISTRY; } >> $BENCH_OUTPUT_FOLDER/vlt-verify.log 2>&1; $BENCH_COLLECT_PKG_COUNT_VLT"
+BENCH_CONCLUDE_AWS="{ $BENCH_VERIFY_REGISTRY; } >> $BENCH_OUTPUT_FOLDER/aws-verify.log 2>&1; $BENCH_COLLECT_PKG_COUNT_AWS"
+BENCH_CONCLUDE_CLOUDSMITH="{ $BENCH_VERIFY_REGISTRY; } >> $BENCH_OUTPUT_FOLDER/cloudsmith-verify.log 2>&1; $BENCH_COLLECT_PKG_COUNT_CLOUDSMITH"
+BENCH_CONCLUDE_GITHUB="{ $BENCH_VERIFY_REGISTRY; } >> $BENCH_OUTPUT_FOLDER/github-verify.log 2>&1; $BENCH_COLLECT_PKG_COUNT_GITHUB"
 
 # Registry commands are timed and should only run installs.
 # Each command is wrapped with `timeout` to prevent runaway installs.
@@ -174,4 +182,12 @@ mkdir -p "$BENCH_OUTPUT_FOLDER"
 # Cleanup function for .npmrc
 registry_cleanup() {
   bash "$BENCH_SCRIPTS/clean-helpers.sh" clean_npmrc
+}
+
+# Function to collect package count data from per-registry count files into package-count.json.
+# Called after the hyperfine run completes — the --conclude hooks have already
+# written <registry>-count.txt files for each iteration.
+collect_registry_package_count() {
+  ls -la "$BENCH_OUTPUT_FOLDER"
+  node "$BENCH_SCRIPTS/collect-package-count.js" "$BENCH_OUTPUT_FOLDER"
 }

--- a/scripts/variations/registry-clean.sh
+++ b/scripts/variations/registry-clean.sh
@@ -32,3 +32,5 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_REG_GITHUB:+--prepare="$BENCH_PREPARE_BASE && $BENCH_SETUP_REGISTRY_GITHUB"} \
   ${BENCH_INCLUDE_REG_GITHUB:+--command-name="github" "$BENCH_COMMAND_GITHUB"} \
   ${BENCH_INCLUDE_REG_GITHUB:+--conclude="$BENCH_CONCLUDE_GITHUB"}
+
+collect_registry_package_count

--- a/scripts/variations/registry-lockfile.sh
+++ b/scripts/variations/registry-lockfile.sh
@@ -33,3 +33,5 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_REG_GITHUB:+--prepare="$BENCH_PREPARE_BASE && $BENCH_SETUP_REGISTRY_GITHUB"} \
   ${BENCH_INCLUDE_REG_GITHUB:+--command-name="github" "$BENCH_COMMAND_GITHUB"} \
   ${BENCH_INCLUDE_REG_GITHUB:+--conclude="$BENCH_CONCLUDE_GITHUB"}
+
+collect_registry_package_count


### PR DESCRIPTION
## Summary

Two improvements requested by @darcyclarke:

### 1. Registry per-package count data & normalization

Adds package count collection for registry benchmarks (registry-clean, registry-lockfile), matching the existing pattern for PM benchmarks. This enables per-package normalization (ms/pkg) for registry variations going forward.

**Pipeline changes:**
- `scripts/registry-package-count.sh` — new script that counts packages in `node_modules` and writes `<registry>-count.txt` (tagged by registry name, unlike `package-count.sh` which infers PM from lockfile)
- `scripts/registry/common.sh` — conclude hooks now collect package counts after each registry install
- `scripts/variations/registry-clean.sh` / `registry-lockfile.sh` — call `collect_registry_package_count` after hyperfine runs
- `scripts/collect-package-count.js` — added aws, cloudsmith, github to recognized count files
- `scripts/process-results.sh` — copies `package-count.json` for registry variations
- `scripts/generate-chart.js` — `generateRegistryChartData({ perPackageCount: true })` produces `registryPerPackageCountChartData`

**App changes:**
- Types: added `registryPerPackageCountChartData` to `BenchmarkChartData`
- `use-chart-data.ts` — consumes and merges registry per-package data; applies DNF fallbacks
- `use-history-data.ts` — extracts `registryPerPackageCountChartData` from each day's data when available
- `variation/index.tsx` — shows per-package chart/table for registry when count data is available

**Note:** Historical data cannot be backfilled — we don't know if registries failed or how many packages were actually installed. Normalization only applies to new runs.

### 2. Fix missing colored boxes in histogram tooltips

The colored indicator squares in bar chart tooltips were invisible because:
- `HorizontalBarTooltipContent` resolved color from `item.fill`/`item.color`, which Recharts derives from the `<Bar>` component's `fill` prop — but horizontal bars have no `fill` prop (each `<Cell>` overrides the visual fill). Now reads from `item.payload?.fill` (the data row's fill field) as primary fallback.
- `ChartTooltipContent` (grouped vertical bars) now prefers `${dataKey}_fill` from the payload as a reliable hex color, avoiding pattern URL strings (`url(#dnf-...)`) from Cell overrides.
- Added missing `dnfColor` to mobile PM bar chart data (was present in desktop/per-package paths but missing in mobile).

### Build verification
```
cd app && npm install && npm run build  # ✅ passes
```
