### PR TITLE
fix: add Benchmark environment to workflow for secrets access

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -84,6 +84,7 @@ jobs:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.app_only != 'true'
     timeout-minutes: 90
+    environment: Benchmark
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The benchmark CI workflow was failing because secrets (AWS_ROLE_ARN, VLT_REGISTRY_AUTH_TOKEN, GH_REGISTRY, GH_AUTH_TOKEN) were moved from repository-level secrets to a GitHub environment called "Benchmark".

The workflow jobs need to declare  to access these environment-level secrets. This change adds the required environment declaration to the benchmark job.

Fixes the CI failures by ensuring the job can access the secrets stored in the Benchmark environment.