### PR TITLE
bench: install aube from next dist-tag

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -50,8 +50,9 @@ npm install -g npm@latest corepack@latest vlt@latest bun@latest deno@latest nx@l
 # Install Vite+ (vp) via npm (available as the `vite-plus` package)
 npm install -g vite-plus@latest
 
-# Install aube via npm (available as the `@endevco/aube` package)
-npm install -g @endevco/aube@latest
+# Install aube via npm. The `latest` dist-tag currently points at an older
+# beta that fails cold fixture installs, while `next` tracks the current beta.
+npm install -g @endevco/aube@next
 
 # Configure Package Managers
 echo "Configuring package managers..."


### PR DESCRIPTION
## Summary

- install Aube from the `next` dist-tag in benchmark setup
- document why this is needed while the `latest` dist-tag still points at an older beta

## Why

The published benchmark data currently installs `@endevco/aube@latest`, which resolves to `1.0.0-beta.2`. That version fails cold fixture installs in the benchmark environment, so Aube is marked DNF for scenarios like `clean` and `lockfile`. The chart then falls back to the slowest value for those cells, which makes the package-manager average and ms/pkg views look much worse than a successful run.

`@endevco/aube@next` currently resolves to `1.0.0-beta.8` and succeeds on the same cold Next fixture install.

## Validation

- `npm install --prefix <tmp> @endevco/aube@next`
- `<tmp>/node_modules/.bin/aube --version` -> `aube 1.0.0-beta.8`
- cold install of `fixtures/next` with isolated `HOME`, `XDG_CACHE_HOME`, and `XDG_DATA_HOME` exited `0`