### PR TITLE
[codex] fix aube version formatting

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -80,7 +80,7 @@ DENO_VERSION="$(npm view deno@latest version)"
 NX_VERSION="$(npm view nx@latest version)"
 TURBO_VERSION="$(npm view turbo@latest version)"
 VP_VERSION="$(npm view vite-plus@latest version 2>/dev/null || echo "unknown")"
-AUBE_VERSION="$(aube --version 2>/dev/null | head -1 | sed 's/^aube //' || echo "unknown")"
+AUBE_VERSION="$(aube --version 2>/dev/null | head -1 | sed -E 's/^aube //; s/[[:space:]]*\\(.*$//; s/[[:space:]].*$//' || echo "unknown")"
 NODE_VERSION=$(node -v)
 
 # Output versions


### PR DESCRIPTION
## Summary

- trim `aube --version` down to the version token before writing `versions.json`
- prevents platform/date suffixes like `linux-arm64 (2026-04-25)` from rendering in benchmark labels

## Root Cause

`aube --version` now includes platform and build date details after the semver. The app expects version values to match the other package managers, so the extra text was shown on the package manager benchmark pages.

## Validation

- `bash -n scripts/setup.sh`
- sample parse: `aube 1.2.0 linux-arm64 (2026-04-25)` -> `1.2.0`
