### PR TITLE
fix: parse aube version from cli output

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -80,7 +80,7 @@ DENO_VERSION="$(npm view deno@latest version)"
 NX_VERSION="$(npm view nx@latest version)"
 TURBO_VERSION="$(npm view turbo@latest version)"
 VP_VERSION="$(npm view vite-plus@latest version 2>/dev/null || echo "unknown")"
-AUBE_VERSION="$(aube --version 2>/dev/null | head -1 | sed -E 's/^aube //; s/[[:space:]]*\\(.*$//; s/[[:space:]].*$//' || echo "unknown")"
+AUBE_VERSION="$(aube --version 2>/dev/null | head -1 | grep -Eo '[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?' | head -1 || true)"
 NODE_VERSION=$(node -v)
 
 # Output versions


### PR DESCRIPTION
## Summary
- parse the aube version from the first semver-looking token in `aube --version`
- leave the version empty when the CLI output is unparseable instead of writing `unknown`

## Why
The benchmark UI prefixes stored package-manager versions with `v`. When `scripts/setup.sh` stores `unknown` for aube, the chart renders `aube vunknown`. The new aube CLI version output is stable as `<version> <os>-<arch> (<date>)`, so extracting the semver token keeps the stored artifact clean while still supporting the older `aube <version>` shape.

## Verification
- `bash -n scripts/setup.sh`
- parser matrix for:
  - `aube 1.0.0-beta.12` -> `1.0.0-beta.12`
  - `1.2.0 linux-x64 (2026-04-26)` -> `1.2.0`
  - `1.2.0-DEBUG macos-arm64 (2026-04-26)` -> `1.2.0-DEBUG`
  - `aube unknown` -> empty, so the UI falls back to `aube` instead of `aube vunknown`
