### PR TITLE
fix: hide per-package chart for registry variations

### DIFF
--- a/app/src/components/variation/index.tsx
+++ b/app/src/components/variation/index.tsx
@@ -147,18 +147,6 @@ export const VariationPage = () => {
   const isTaskExecution = isTaskExecutionVariation(variation as string);
   const isRegistry = isRegistryVariation(variation as string);
 
-  // For registry variations, check if per-package data actually contains
-  // count fields (indicating package counts were collected). Without counts
-  // the per-package data is identical to total time — don't show the section.
-  const hasRegistryPerPackageData =
-    isRegistry &&
-    filteredPerPackageVariationData.some((fixture) =>
-      packageManagers.some((pm) => {
-        const countKey = `${pm}_count` as keyof FixtureResult;
-        return typeof fixture[countKey] === "number";
-      }),
-    );
-
   // Dynamic titles and section IDs based on variation type
   const titles = isTaskExecution
     ? {
@@ -223,8 +211,8 @@ export const VariationPage = () => {
         />
       </div>
 
-      {/* 1. Per-package fixture charts - show for PM tests and registry when data available */}
-      {(!isTaskExecution && !isRegistry) || hasRegistryPerPackageData ? (
+      {/* 1. Per-package fixture charts - only for package manager variations */}
+      {!isTaskExecution && !isRegistry ? (
         <div id={sectionIds.perPackageChart}>
           <VariationChart
             title={titles.perPackageChart}
@@ -239,8 +227,8 @@ export const VariationPage = () => {
       ) : null}
 
       <div className="space-y-8">
-        {/* 2. Per-package fixture data table - show for PM tests and registry when data available */}
-        {(!isTaskExecution && !isRegistry) || hasRegistryPerPackageData ? (
+        {/* 2. Per-package fixture data table - only for package manager variations */}
+        {!isTaskExecution && !isRegistry ? (
           <div id={sectionIds.perPackageTable}>
             <VariationTable
               title={titles.perPackageTable}


### PR DESCRIPTION
## Summary

Registry variations render both the "total time" chart and the "per-package time" chart as horizontal bar charts with only a few entries, making them look like duplicated data. This PR hides the per-package chart and its corresponding data table for registry variations.

### Changes

- **`app/src/components/variation/index.tsx`**: Simplified the per-package chart/table visibility condition to always exclude registries (`!isTaskExecution && !isRegistry`), removing the now-unnecessary `hasRegistryPerPackageData` check
- Package manager variations continue to show both charts as before
- Task execution variations continue to hide per-package charts as before

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>