### PR TITLE
feat: surface historical cloudsmith registry data in history charts

### DIFF
--- a/app/src/components/history-chart.tsx
+++ b/app/src/components/history-chart.tsx
@@ -34,6 +34,14 @@ const RANGE_OPTIONS = [
   { label: "All", days: Infinity },
 ] as const;
 
+/**
+ * Fallback colors for package managers that may only exist in historical data
+ * (e.g. cloudsmith was removed from active benchmarks but old results remain).
+ */
+const HISTORY_FALLBACK_COLORS: Partial<Record<PackageManager, string>> = {
+  cloudsmith: "#2C5BB4",
+};
+
 interface HistoryChartProps {
   historyData: HistoryData;
   currentVariation: string;
@@ -62,9 +70,35 @@ export const HistoryChart = ({
 
   const variationData = historyData.variations[currentVariation];
 
+  // Merge PMs from the current chart data with PMs that only exist in
+  // historical data (e.g. cloudsmith).  This ensures discontinued PMs
+  // still appear in the history chart even though they're absent from
+  // today's benchmark results.
+  const allHistoryPMs = useMemo((): PackageManager[] => {
+    if (!variationData) return packageManagers;
+    const currentSet = new Set<PackageManager>(packageManagers);
+    const ordered = [...packageManagers];
+    for (const pm of Object.keys(variationData) as PackageManager[]) {
+      if (
+        !currentSet.has(pm) &&
+        variationData[pm]?.some((v) => v !== null && v !== undefined)
+      ) {
+        ordered.push(pm);
+        currentSet.add(pm);
+      }
+    }
+    return ordered;
+  }, [packageManagers, variationData]);
+
   const filteredPMs = useMemo(
-    () => packageManagers.filter((pm) => enabledPackageManagers.has(pm)),
-    [packageManagers, enabledPackageManagers],
+    () =>
+      allHistoryPMs.filter(
+        (pm) =>
+          // Include if globally enabled OR if it only exists in history
+          // (not in the global filter's initial set — it won't be togglable)
+          enabledPackageManagers.has(pm) || !packageManagers.includes(pm),
+      ),
+    [allHistoryPMs, enabledPackageManagers, packageManagers],
   );
 
   const [selectedPMs, setSelectedPMs] = useState<Set<string>>(
@@ -77,7 +111,9 @@ export const HistoryChart = ({
   }, [filteredPMs]);
 
   const getColor = (pm: PackageManager) =>
-    pm === "vlt" && resolvedTheme === "dark" ? "white" : colors[pm];
+    pm === "vlt" && resolvedTheme === "dark"
+      ? "white"
+      : colors[pm] ?? HISTORY_FALLBACK_COLORS[pm] ?? "#888888";
 
   const handleLegendClick = (pm: string) => {
     setSelectedPMs((prev) => {

--- a/scripts/generate-chart.js
+++ b/scripts/generate-chart.js
@@ -45,7 +45,7 @@ const REGISTRY_COLORS = {
   npm: "#cb0606",
   vlt: "#000000",
   aws: "#ff9900",
-
+  cloudsmith: "#2C5BB4",
   github: "#6336b8",
 };
 


### PR DESCRIPTION
## Summary

The history chart previously only showed package managers present in today's benchmark data. Since cloudsmith was removed from active benchmarks, its historical data (March 11 – April 5, 2026) was invisible in the registry variation history graphs (`registry-clean`, `registry-lockfile`).

## Changes

### `app/src/components/history-chart.tsx`
- **Merge historical PMs**: The chart now discovers package managers from the history data itself (via `allHistoryPMs` memo) and merges them with the current day's PM list. Discontinued registries like cloudsmith appear alongside active ones.
- **Filter bypass**: PMs that only exist in history (not in the global filter's initial set) bypass the global package manager filter — they're always shown since users can't toggle them.
- **Fallback colors**: Added `HISTORY_FALLBACK_COLORS` map (`cloudsmith: #2C5BB4`) so history-only PMs get proper colors even when absent from today's color palette.
- **Graceful degradation**: The `getColor` function falls through: today's colors → history fallback → generic `#888888`.

### `scripts/generate-chart.js`
- Added `cloudsmith: "#2C5BB4"` to `REGISTRY_COLORS` for consistency (in case cloudsmith benchmarks are re-enabled in the future).

## How it works

The `use-history-data.ts` hook already fetches all historical chart-data.json files and extracts data for all PMs (including cloudsmith). The hook's `PACKAGE_MANAGERS` array already included `cloudsmith`. The issue was purely in the rendering layer:

1. `VariationPage` computed `packageManagers` from today's fixture data only
2. `HistoryChart` filtered its lines to only those PMs
3. Cloudsmith data was fetched but never rendered

Now the HistoryChart independently discovers which PMs have data in the history and includes them.

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>