### PR TITLE
feat: label npm as baseline reference in registry benchmarks

### DIFF
--- a/app/src/components/header.tsx
+++ b/app/src/components/header.tsx
@@ -13,6 +13,7 @@ import {
   getAvailablePackageManagers,
   getVariationCategories,
   getPackageManagerDisplayName,
+  isBaselinePackageManager,
   sortVariations,
 } from "@/lib/utils";
 import type { LeaderboardRoute } from "@/lib/utils";
@@ -287,6 +288,7 @@ interface LeaderBoardItemProps {
   averageTime: number;
   idx: number;
   unit?: string;
+  isBaseline?: boolean;
 }
 
 const LeaderBoardItem = ({
@@ -294,6 +296,7 @@ const LeaderBoardItem = ({
   averageTime,
   idx,
   unit = "ms/pkg",
+  isBaseline = false,
 }: LeaderBoardItemProps) => {
   const Icon = getPackageManagerIcon(packageManager);
   const rank = idx + 1;
@@ -306,7 +309,10 @@ const LeaderBoardItem = ({
       : `${averageTime.toFixed(2)}s`;
 
   return (
-    <div className="relative flex bg-card items-center gap-2.5 px-3 py-2 rounded-lg border border-border/50 flex-shrink-0 whitespace-nowrap min-w-[120px]">
+    <div className={cn(
+      "relative flex bg-card items-center gap-2.5 px-3 py-2 rounded-lg border flex-shrink-0 whitespace-nowrap min-w-[120px]",
+      isBaseline ? "border-dashed border-border" : "border-border/50",
+    )}>
       <div className="text-lg text-muted-foreground font-mono font-medium flex-shrink-0">
         {rank}
       </div>
@@ -321,7 +327,14 @@ const LeaderBoardItem = ({
           )}
         </div>
         <div className="flex flex-col">
-          <p className="text-xs font-medium">{displayName}</p>
+          <p className="text-xs font-medium">
+            {displayName}
+            {isBaseline && (
+              <span className="ml-1 text-[10px] font-normal italic text-muted-foreground">
+                baseline
+              </span>
+            )}
+          </p>
           <p className="text-[10px] text-muted-foreground">{formattedTime}</p>
         </div>
       </div>
@@ -336,6 +349,7 @@ const HeaderLeaderboard = forwardRef<HTMLDivElement, ComponentProps<"div">>(
     const { chartData, location, currentVariation } = useHeaderContext();
 
     const baseRoute = location.pathname.split("/")[1] as LeaderboardRoute;
+    const isRegistryRoute = baseRoute === "registries";
 
     // Determine the unit label based on route
     const unit =
@@ -368,6 +382,7 @@ const HeaderLeaderboard = forwardRef<HTMLDivElement, ComponentProps<"div">>(
                 averageTime={item.averageTime}
                 packageManager={item.packageManager}
                 unit={unit}
+                isBaseline={isBaselinePackageManager(item.packageManager, isRegistryRoute)}
               />
             ))}
         </div>

--- a/app/src/components/variation/chart.tsx
+++ b/app/src/components/variation/chart.tsx
@@ -22,6 +22,7 @@ import {
   createSectionId,
   isRegistryVariation,
   isTaskExecutionVariation,
+  isBaselinePackageManager,
 } from "@/lib/utils";
 import { resolveTheme, useTheme } from "@/components/theme-provider";
 import { usePackageManagerFilter } from "@/contexts/package-manager-filter-context";
@@ -124,6 +125,8 @@ const HorizontalBarTooltipContent = ({
               item.fill ||
               item.color;
 
+          const isBaseline = item.payload?.isBaseline === true;
+
           return (
             <div key={index} className="flex items-center gap-2">
               <div
@@ -131,12 +134,17 @@ const HorizontalBarTooltipContent = ({
                 style={
                   isDnf && color
                     ? { background: getDnfGradient(color) }
-                    : { backgroundColor: color }
+                    : { backgroundColor: color, opacity: isBaseline ? 0.6 : 1 }
                 }
               />
               <div className="flex flex-1 justify-between items-center gap-4">
                 <span className="text-muted-foreground">
                   {item.name ?? item.dataKey}
+                  {isBaseline && (
+                    <span className="ml-1 text-[10px] italic opacity-70">
+                      baseline
+                    </span>
+                  )}
                 </span>
                 <span className="text-foreground font-mono font-medium tabular-nums">
                   {isDnf
@@ -478,6 +486,7 @@ export const VariationChart = ({
                     : getColor(pm),
                   dnf: isDnf,
                   dnfColor: getColor(pm),
+                  isBaseline: isBaselinePackageManager(pm, isRegistry),
                 };
               })
               .filter(Boolean)
@@ -540,14 +549,55 @@ export const VariationChart = ({
                         type="category"
                         dataKey="name"
                         width={isMobile ? 70 : 120}
-                        tick={{
+                        tick={isRegistry ? ((props: Record<string, unknown>) => {
+                          const x = Number(props.x) || 0;
+                          const y = Number(props.y) || 0;
+                          const payload = props.payload as { value: string; index: number } | undefined;
+                          const index = payload?.index ?? 0;
+                          const entry = barData[index];
+                          const isBaselineEntry = entry?.isBaseline === true;
+                          let label = payload?.value ?? "";
+                          if (isMobile) {
+                            const parts = label.split(" v");
+                            label = parts[0] ?? label;
+                          } else {
+                            label = normalizeTickLabel(label);
+                          }
+                          return (
+                            <g transform={`translate(${x},${y})`}>
+                              <text
+                                x={0}
+                                y={0}
+                                dy={4}
+                                textAnchor="end"
+                                fontSize={isMobile ? 10 : 12}
+                                fill={resolvedTheme === "dark" ? "white" : "currentColor"}
+                              >
+                                {label}
+                              </text>
+                              {isBaselineEntry && (
+                                <text
+                                  x={0}
+                                  y={0}
+                                  dy={isMobile ? 16 : 18}
+                                  textAnchor="end"
+                                  fontSize={isMobile ? 8 : 9}
+                                  fill={resolvedTheme === "dark" ? "#a1a1aa" : "#71717a"}
+                                  fontStyle="italic"
+                                >
+                                  baseline
+                                </text>
+                              )}
+                            </g>
+                          );
+                        }) as unknown as undefined : {
                           fontSize: isMobile ? 10 : 12,
                           fill:
                             resolvedTheme === "dark"
                               ? "white"
                               : "currentColor",
                         }}
-                        tickFormatter={(label: string) => {
+                        tickFormatter={isRegistry ? undefined : (label: string) => {
                           if (isMobile) {
                             const parts = label.split(" v");
                             return parts[0] ?? label;
@@ -559,9 +609,19 @@ export const VariationChart = ({
                         content={<HorizontalBarTooltipContent />}
                       />
                       <Bar dataKey="value" maxBarSize={32}>
-                        {barData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={entry?.fill} />
-                        ))}
+                        {barData.map((entry, index) => {
+                          const isBaseline = entry?.isBaseline === true;
+                          return (
+                            <Cell
+                              key={`cell-${index}`}
+                              fill={entry?.fill}
+                              opacity={isBaseline ? 0.6 : 1}
+                              strokeDasharray={isBaseline ? "4 2" : undefined}
+                              stroke={isBaseline ? entry?.dnfColor || entry?.fill : undefined}
+                              strokeWidth={isBaseline ? 1.5 : 0}
+                            />
+                          );
+                        })}
                       </Bar>
                     </BarChart>
                   </ResponsiveContainer>
@@ -570,6 +630,16 @@ export const VariationChart = ({
             );
           })}
         </div>
+
+        {/* Baseline footnote for registry variations */}
+        {isRegistry && (
+          <p className="text-xs text-muted-foreground italic px-1">
+            * registry.npmjs.org is included as the baseline reference — it
+            represents the standard npm registry that package-manager benchmarks
+            already test against, providing context for comparing alternative
+            registry speeds.
+          </p>
+        )}
       </div>
     );
   }

--- a/app/src/components/variation/index.tsx
+++ b/app/src/components/variation/index.tsx
@@ -187,6 +187,19 @@ export const VariationPage = () => {
 
   return (
     <div className="space-y-12">
+      {/* Registry baseline context note */}
+      {isRegistry && (
+        <div className="rounded-lg border border-border bg-card/50 px-4 py-3 text-sm text-muted-foreground">
+          <strong className="text-foreground">About this benchmark:</strong>{" "}
+          These tests measure <code className="text-xs bg-muted px-1 py-0.5 rounded">npm install</code> times
+          across different registries using the same npm client. The{" "}
+          <em>registry.npmjs.org</em> result is included as the{" "}
+          <strong className="text-foreground">baseline reference</strong> — it
+          represents the default npm registry and provides context for comparing
+          alternative registry performance.
+        </div>
+      )}
+
       {/* History chart - performance over time */}
       {historyData && (
         <HistoryChart

--- a/app/src/components/variation/table.tsx
+++ b/app/src/components/variation/table.tsx
@@ -23,6 +23,7 @@ import {
   sortFixtures,
   createSectionId,
   isRegistryVariation,
+  isBaselinePackageManager,
 } from "@/lib/utils";
 import { ShareButton } from "@/components/share-button";
 import { usePackageManagerFilter } from "@/contexts/package-manager-filter-context";
@@ -123,14 +124,29 @@ export const VariationTable = ({
           const displayName = getPackageManagerDisplayName(packageManager, {
             isRegistryVariation: isRegistry,
           });
+          const isBaseline = isBaselinePackageManager(packageManager, isRegistry);
 
           return version ? (
             <div className="text-left">
-              <div className="font-bold">{displayName}</div>
+              <div className="font-bold flex items-center gap-1.5">
+                {displayName}
+                {isBaseline && (
+                  <span className="text-[10px] font-normal italic text-muted-foreground">
+                    baseline
+                  </span>
+                )}
+              </div>
               <div className="text-xs text-muted-foreground">{version}</div>
             </div>
           ) : (
-            <span className="font-bold">{displayName}</span>
+            <div className="text-left">
+              <span className="font-bold">{displayName}</span>
+              {isBaseline && (
+                <span className="ml-1.5 text-[10px] font-normal italic text-muted-foreground">
+                  baseline
+                </span>
+              )}
+            </div>
           );
         },
         enableSorting: true,

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -184,7 +184,8 @@ export const getVariationCategories = (
   if (registryVariations.length > 0) {
     categories.push({
       title: "Registries",
-      description: "npm install times across different registries",
+      description:
+        "npm install times across different registries (npm registry serves as baseline)",
       variations: sortVariations(registryVariations),
     });
   }
@@ -490,6 +491,13 @@ export function getFixtureDisplayName(fixture: Fixture): string {
     default:
       return fixture;
   }
+}
+
+export function isBaselinePackageManager(
+  packageManager: PackageManager,
+  isRegistryVariation?: boolean,
+): boolean {
+  return isRegistryVariation === true && packageManager === "npm";
 }
 
 export function getPackageManagerDisplayName(


### PR DESCRIPTION
## Summary

The "npm" column in registry-clean/registry-lockfile benchmarks is intentionally kept as the control/baseline since it helps contextualize vlt/aws/github registry speeds. This PR adds proper labeling and documentation to make that role clear.

## Changes

### UI Indicators
- **Chart Y-axis**: Shows italic "baseline" label below the `registry.npmjs.org` tick on horizontal bar charts
- **Bar style**: npm bars render at 60% opacity with a dashed stroke border to visually distinguish them from the registries being benchmarked
- **Tooltip**: Shows "baseline" annotation when hovering over npm entries
- **Data tables**: Shows italic "baseline" badge next to `registry.npmjs.org` in the registry column
- **Leaderboard**: npm card gets a dashed border and "baseline" label when viewing registry routes

### Documentation
- **Context banner**: Added an informational note at the top of registry variation pages explaining the benchmark methodology and npm's baseline role
- **Chart footnote**: Added explanatory footnote below registry charts
- **Category description**: Updated the Registries category description to mention the baseline

## Screenshots

All changes are scoped to registry benchmark views only — package manager and task runner benchmarks are unaffected.

---

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>