### PR TITLE
feat: add pacquet PM + unify pnpm variant display names

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -11,7 +11,7 @@ on:
         default: '["clean", "node_modules", "cache", "cache+node_modules", "cache+lockfile", "cache+lockfile+node_modules", "lockfile", "lockfile+node_modules", "build", "build-cache", "registry-clean", "registry-lockfile"]'
       binaries:
         description: "The binaries to run the benchmarks on"
-        default: '"npm,yarn,berry,zpm,pnpm,pnpm11,vlt,bun,deno,aube,nx,turbo,vp,node"'
+        default: '"npm,yarn,berry,zpm,pnpm,pnpm11,pacquet,vlt,bun,deno,aube,nx,turbo,vp,node"'
       warmup:
         description: "The number of warmup runs on each benchmark"
         default: "2"
@@ -101,7 +101,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      BENCH_INCLUDE: ${{ fromJson(inputs.binaries || '"npm,yarn,berry,zpm,pnpm,pnpm11,vlt,bun,deno,aube,nx,turbo,vp,node"') }}
+      BENCH_INCLUDE: ${{ fromJson(inputs.binaries || '"npm,yarn,berry,zpm,pnpm,pnpm11,pacquet,vlt,bun,deno,aube,nx,turbo,vp,node"') }}
       BENCH_WARMUP: ${{ (github.event_name == 'push' && github.ref != 'refs/heads/main') && '1' || (inputs.warmup || '2') }}
       BENCH_RUNS: ${{ (github.event_name == 'push' && github.ref != 'refs/heads/main') && '1' || (inputs.runs || '5') }}
     steps:

--- a/app/src/hooks/use-history-data.ts
+++ b/app/src/hooks/use-history-data.ts
@@ -12,6 +12,7 @@ const PACKAGE_MANAGERS = [
   "yarn",
   "pnpm",
   "pnpm11",
+  "pacquet",
   "berry",
   "zpm",
   "deno",

--- a/app/src/lib/get-icons.ts
+++ b/app/src/lib/get-icons.ts
@@ -37,6 +37,7 @@ const packageManagerMap: Partial<Record<PackageManager, LucideIcon>> = {
   nx: Nx,
   pnpm: Pnpm,
   pnpm11: Pnpm,
+  pacquet: Pnpm,
   turbo: Turbo,
   vp: Vp,
   yarn: Yarn,

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -231,6 +231,7 @@ export const calculateLeaderboard = (
               "npm",
               "pnpm",
               "pnpm11",
+              "pacquet",
               "yarn",
               "zpm",
               "berry",
@@ -514,6 +515,9 @@ export function getPackageManagerDisplayName(
     if (packageManager === "cloudsmith") return "npm.cloudsmith.io";
     if (packageManager === "github") return "npm.pkg.github.com";
   }
+  if (packageManager === "pnpm") return "pnpm (v10)";
+  if (packageManager === "pnpm11") return "pnpm (v11)";
+  if (packageManager === "pacquet") return "pnpm (pacquet)";
   if (packageManager === "berry") return "yarn (berry)";
   if (packageManager === "zpm") return "yarn (zpm)";
   if (packageManager === "turbo") return "turborepo";

--- a/app/src/types/chart-data.ts
+++ b/app/src/types/chart-data.ts
@@ -3,6 +3,7 @@ export type PackageManager =
   | "yarn"
   | "pnpm"
   | "pnpm11"
+  | "pacquet"
   | "berry"
   | "zpm"
   | "deno"
@@ -49,6 +50,7 @@ export interface PackageManagerVersions {
   yarn?: string;
   pnpm?: string;
   pnpm11?: string;
+  pacquet?: string;
   berry?: string;
   zpm?: string;
   deno?: string;
@@ -73,6 +75,7 @@ export interface PackageManagerData {
   yarn?: number;
   pnpm?: number;
   pnpm11?: number;
+  pacquet?: number;
   berry?: number;
   zpm?: number;
   deno?: number;
@@ -91,6 +94,7 @@ export interface PackageManagerData {
   yarn_stddev?: number;
   pnpm_stddev?: number;
   pnpm11_stddev?: number;
+  pacquet_stddev?: number;
   berry_stddev?: number;
   zpm_stddev?: number;
   deno_stddev?: number;
@@ -109,6 +113,7 @@ export interface PackageManagerData {
   yarn_fill?: string;
   pnpm_fill?: string;
   pnpm11_fill?: string;
+  pacquet_fill?: string;
   berry_fill?: string;
   zpm_fill?: string;
   deno_fill?: string;
@@ -127,6 +132,7 @@ export interface PackageManagerData {
   yarn_count?: number;
   pnpm_count?: number;
   pnpm11_count?: number;
+  pacquet_count?: number;
   berry_count?: number;
   zpm_count?: number;
   deno_count?: number;
@@ -145,6 +151,7 @@ export interface PackageManagerData {
   yarn_dnf?: boolean;
   pnpm_dnf?: boolean;
   pnpm11_dnf?: boolean;
+  pacquet_dnf?: boolean;
   berry_dnf?: boolean;
   zpm_dnf?: boolean;
   deno_dnf?: boolean;
@@ -190,6 +197,7 @@ export interface PackageCountData {
   yarn?: PackageCountEntry;
   pnpm?: PackageCountEntry;
   pnpm11?: PackageCountEntry;
+  pacquet?: PackageCountEntry;
   berry?: PackageCountEntry;
   zpm?: PackageCountEntry;
   deno?: PackageCountEntry;
@@ -216,6 +224,7 @@ export interface ProcessCountData {
   yarn?: PackageCountEntry;
   pnpm?: PackageCountEntry;
   pnpm11?: PackageCountEntry;
+  pacquet?: PackageCountEntry;
   berry?: PackageCountEntry;
   zpm?: PackageCountEntry;
   deno?: PackageCountEntry;

--- a/bench
+++ b/bench
@@ -30,6 +30,7 @@ AVAILABLE_PMS=(
   zpm
   pnpm
   pnpm11
+  pacquet
   vlt
   bun
   deno

--- a/scripts/clean-helpers.sh
+++ b/scripts/clean-helpers.sh
@@ -48,6 +48,17 @@ clean_pnpm_cache() {
   safe_remove "$HOME/.local/share/pnpm/store"
 }
 
+# Function to safely clean pacquet cache
+# pacquet shares pnpm's content-addressable store layout
+clean_pacquet_cache() {
+  if command -v pacquet &> /dev/null; then
+    # pacquet uses the same store path as pnpm; the parent dirs are cleaned
+    # by clean_pnpm_cache, but if called in isolation we still handle them.
+    safe_remove "$HOME/.cache/pnpm"
+    safe_remove "$HOME/.local/share/pnpm/store"
+  fi
+}
+
 # Function to safely clean pnpm 11 cache
 clean_pnpm11_cache() {
   if command -v corepack &> /dev/null; then
@@ -183,6 +194,7 @@ clean_all_cache() {
   clean_zpm_cache
   clean_pnpm_cache
   clean_pnpm11_cache
+  clean_pacquet_cache
   clean_vlt_cache
   clean_bun_cache
   clean_nx_cache
@@ -239,6 +251,7 @@ show_help() {
   echo "  clean_zpm_cache"
   echo "  clean_pnpm_cache"
   echo "  clean_pnpm11_cache"
+  echo "  clean_pacquet_cache"
   echo "  clean_vlt_cache"
   echo "  clean_bun_cache"
   echo "  clean_nx_cache"
@@ -280,6 +293,9 @@ else
         ;;
       clean_pnpm11_cache)
         clean_pnpm11_cache
+        ;;
+      clean_pacquet_cache)
+        clean_pacquet_cache
         ;;
       clean_vlt_cache)
         clean_vlt_cache

--- a/scripts/collect-package-count.js
+++ b/scripts/collect-package-count.js
@@ -26,6 +26,7 @@ const countFiles = [
   { filename: 'zpm-count.txt', pmName: 'zpm' },
   { filename: 'pnpm-count.txt', pmName: 'pnpm' },
   { filename: 'pnpm11-count.txt', pmName: 'pnpm11' },
+  { filename: 'pacquet-count.txt', pmName: 'pacquet' },
   { filename: 'vlt-count.txt', pmName: 'vlt' },
   { filename: 'bun-count.txt', pmName: 'bun' },
   { filename: 'deno-count.txt', pmName: 'deno' },

--- a/scripts/collect-process-count.js
+++ b/scripts/collect-process-count.js
@@ -26,6 +26,7 @@ const countFiles = [
   { filename: 'zpm-process-count.txt', pmName: 'zpm' },
   { filename: 'pnpm-process-count.txt', pmName: 'pnpm' },
   { filename: 'pnpm11-process-count.txt', pmName: 'pnpm11' },
+  { filename: 'pacquet-process-count.txt', pmName: 'pacquet' },
   { filename: 'vlt-process-count.txt', pmName: 'vlt' },
   { filename: 'bun-process-count.txt', pmName: 'bun' },
   { filename: 'deno-process-count.txt', pmName: 'deno' },

--- a/scripts/generate-chart.js
+++ b/scripts/generate-chart.js
@@ -28,6 +28,7 @@ const COLORS = {
   yarn: "#117cad",
   pnpm: "#f9ad00",
   pnpm11: "#e68a00",
+  pacquet: "#d4740a",
   berry: "#9555bb",
   zpm: "#7388ff",
   deno: "#70ffaf",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -45,7 +45,7 @@ echo "hyperfine: $HYPERFINE_VERSION"
 
 # Install Node.js package managers and tools
 echo "Installing package managers and tools..."
-npm install -g npm@latest corepack@latest vlt@latest bun@latest deno@latest nx@latest turbo@latest
+npm install -g npm@latest corepack@latest vlt@latest bun@latest deno@latest nx@latest turbo@latest pacquet@latest
 
 # Install Vite+ (vp) via npm (available as the `vite-plus` package)
 npm install -g vite-plus@latest
@@ -75,6 +75,7 @@ BERRY_VERSION="$(corepack yarn@latest -v)"
 ZPM_VERSION="$(curl https://repo.yarnpkg.com/channels/default/canary)"
 PNPM_VERSION="$(corepack pnpm@latest -v)"
 PNPM11_VERSION="$(corepack pnpm@next-11 -v)"
+PACQUET_VERSION="$(pacquet --version 2>/dev/null | head -1 | grep -Eo '[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?' | head -1 || echo "unknown")"
 BUN_VERSION="$(bun -v)"
 DENO_VERSION="$(npm view deno@latest version)"
 NX_VERSION="$(npm view nx@latest version)"
@@ -91,6 +92,7 @@ echo "yarn (berry): $BERRY_VERSION"
 echo "yarn (zpm): $ZPM_VERSION"
 echo "pnpm: $PNPM_VERSION"
 echo "pnpm11: $PNPM11_VERSION"
+echo "pacquet: $PACQUET_VERSION"
 echo "bun: $BUN_VERSION"
 echo "deno: $DENO_VERSION"
 echo "nx: $NX_VERSION"
@@ -108,6 +110,7 @@ echo "{
   \"zpm\": \"$ZPM_VERSION\",
   \"pnpm\": \"$PNPM_VERSION\",
   \"pnpm11\": \"$PNPM11_VERSION\",
+  \"pacquet\": \"$PACQUET_VERSION\",
   \"bun\": \"$BUN_VERSION\",
   \"deno\": \"$DENO_VERSION\",
   \"nx\": \"$NX_VERSION\",

--- a/scripts/variations/cache+lockfile+node_modules.sh
+++ b/scripts/variations/cache+lockfile+node_modules.sh
@@ -30,6 +30,8 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_PNPM:+--command-name="pnpm" "$BENCH_COMMAND_PNPM"} \
   ${BENCH_INCLUDE_PNPM11:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PNPM11")"} \
   ${BENCH_INCLUDE_PNPM11:+--command-name="pnpm11" "$BENCH_COMMAND_PNPM11"} \
+  ${BENCH_INCLUDE_PACQUET:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PACQUET")"} \
+  ${BENCH_INCLUDE_PACQUET:+--command-name="pacquet" "$BENCH_COMMAND_PACQUET"} \
   ${BENCH_INCLUDE_VLT:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_VLT")"} \
   ${BENCH_INCLUDE_VLT:+--command-name="vlt" "$BENCH_COMMAND_VLT"} \
   ${BENCH_INCLUDE_BUN:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_BUN")"} \

--- a/scripts/variations/cache+lockfile.sh
+++ b/scripts/variations/cache+lockfile.sh
@@ -30,6 +30,8 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_PNPM:+--command-name="pnpm" "$BENCH_COMMAND_PNPM"} \
   ${BENCH_INCLUDE_PNPM11:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PNPM11")"} \
   ${BENCH_INCLUDE_PNPM11:+--command-name="pnpm11" "$BENCH_COMMAND_PNPM11"} \
+  ${BENCH_INCLUDE_PACQUET:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PACQUET")"} \
+  ${BENCH_INCLUDE_PACQUET:+--command-name="pacquet" "$BENCH_COMMAND_PACQUET"} \
   ${BENCH_INCLUDE_VLT:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_VLT")"} \
   ${BENCH_INCLUDE_VLT:+--command-name="vlt" "$BENCH_COMMAND_VLT"} \
   ${BENCH_INCLUDE_BUN:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_BUN")"} \

--- a/scripts/variations/cache+node_modules.sh
+++ b/scripts/variations/cache+node_modules.sh
@@ -30,6 +30,8 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_PNPM:+--command-name="pnpm" "$BENCH_COMMAND_PNPM"} \
   ${BENCH_INCLUDE_PNPM11:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PNPM11")"} \
   ${BENCH_INCLUDE_PNPM11:+--command-name="pnpm11" "$BENCH_COMMAND_PNPM11"} \
+  ${BENCH_INCLUDE_PACQUET:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PACQUET")"} \
+  ${BENCH_INCLUDE_PACQUET:+--command-name="pacquet" "$BENCH_COMMAND_PACQUET"} \
   ${BENCH_INCLUDE_VLT:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_VLT")"} \
   ${BENCH_INCLUDE_VLT:+--command-name="vlt" "$BENCH_COMMAND_VLT"} \
   ${BENCH_INCLUDE_BUN:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_BUN")"} \

--- a/scripts/variations/cache.sh
+++ b/scripts/variations/cache.sh
@@ -30,6 +30,8 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_PNPM:+--command-name="pnpm" "$BENCH_COMMAND_PNPM"} \
   ${BENCH_INCLUDE_PNPM11:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PNPM11")"} \
   ${BENCH_INCLUDE_PNPM11:+--command-name="pnpm11" "$BENCH_COMMAND_PNPM11"} \
+  ${BENCH_INCLUDE_PACQUET:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PACQUET")"} \
+  ${BENCH_INCLUDE_PACQUET:+--command-name="pacquet" "$BENCH_COMMAND_PACQUET"} \
   ${BENCH_INCLUDE_VLT:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_VLT")"} \
   ${BENCH_INCLUDE_VLT:+--command-name="vlt" "$BENCH_COMMAND_VLT"} \
   ${BENCH_INCLUDE_BUN:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_BUN")"} \

--- a/scripts/variations/clean.sh
+++ b/scripts/variations/clean.sh
@@ -30,6 +30,8 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_PNPM:+--command-name="pnpm" "$BENCH_COMMAND_PNPM"} \
   ${BENCH_INCLUDE_PNPM11:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PNPM11")"} \
   ${BENCH_INCLUDE_PNPM11:+--command-name="pnpm11" "$BENCH_COMMAND_PNPM11"} \
+  ${BENCH_INCLUDE_PACQUET:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PACQUET")"} \
+  ${BENCH_INCLUDE_PACQUET:+--command-name="pacquet" "$BENCH_COMMAND_PACQUET"} \
   ${BENCH_INCLUDE_VLT:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_VLT")"} \
   ${BENCH_INCLUDE_VLT:+--command-name="vlt" "$BENCH_COMMAND_VLT"} \
   ${BENCH_INCLUDE_BUN:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_BUN")"} \

--- a/scripts/variations/common.sh
+++ b/scripts/variations/common.sh
@@ -31,14 +31,14 @@ else
 fi
 
 # Defines configurable values for the benchmark
-BENCH_INCLUDE="${BENCH_INCLUDE:=npm,yarn,berry,zpm,pnpm,pnpm11,vlt,bun,deno,aube,nx,turbo,vp,node}"
+BENCH_INCLUDE="${BENCH_INCLUDE:=npm,yarn,berry,zpm,pnpm,pnpm11,pacquet,vlt,bun,deno,aube,nx,turbo,vp,node}"
 BENCH_WARMUP="${BENCH_WARMUP:=2}"
 BENCH_RUNS="${BENCH_RUNS:=5}"
 # Per-command timeout in seconds (default: 5 minutes).
 # If a single install exceeds this, it is killed. hyperfine --ignore-failure
 # lets the suite continue; the timed-out run records as a failure.
 BENCH_TIMEOUT="${BENCH_TIMEOUT:=300}"
-for pm in npm yarn berry zpm pnpm pnpm11 vlt bun deno aube nx turbo vp node; do
+for pm in npm yarn berry zpm pnpm pnpm11 pacquet vlt bun deno aube nx turbo vp node; do
   CHOICE=$(echo "$pm" | tr '[:lower:]' '[:upper:]')
   if echo "$BENCH_INCLUDE" | grep -qw "$pm"; then
     # Only allow nx, turbo, vp, node for task-runner variations (run, build, build-cache)
@@ -72,6 +72,7 @@ BENCH_SETUP_BERRY="echo \"$BENCH_COMMAND_YARN_MODERN_CONFIG\" > .yarnrc.yml"
 BENCH_SETUP_ZPM="echo \"$BENCH_COMMAND_YARN_MODERN_CONFIG\" > .yarnrc.yml; { echo '[zpm prepare]'; echo 'cwd:'; pwd; echo 'package.json:'; ls -la package.json || true; echo 'yarn path:'; command -v yarn || true; echo 'yarn version:'; yarn -v || true; echo 'canary version:'; echo \"$BENCH_ZPM_VERSION\"; echo 'packageManager (before):'; npm pkg get packageManager || true; echo 'set packageManager=yarn@'"$BENCH_ZPM_VERSION"':' ; npm pkg set packageManager=\"yarn@$BENCH_ZPM_VERSION\" || true; echo 'packageManager (after):'; npm pkg get packageManager || true; } >> $BENCH_OUTPUT_FOLDER/zpm-prepare.log 2>&1"
 BENCH_SETUP_PNPM=""
 BENCH_SETUP_PNPM11=""
+BENCH_SETUP_PACQUET=""
 BENCH_SETUP_VLT="node $BENCH_SCRIPTS/add-workspace-protocol.js . >> $BENCH_OUTPUT_FOLDER/vlt-prepare.log 2>&1"
 BENCH_SETUP_BUN=""
 BENCH_SETUP_DENO=""
@@ -98,6 +99,7 @@ BENCH_INSTALL_BERRY="corepack yarn@latest install"
 BENCH_INSTALL_ZPM="yarn install --silent"
 BENCH_INSTALL_PNPM="corepack pnpm@latest install --silent"
 BENCH_INSTALL_PNPM11="corepack pnpm@next-11 install --ignore-scripts --silent"
+BENCH_INSTALL_PACQUET="pacquet install"
 BENCH_INSTALL_VLT="vlt install --view=silent"
 BENCH_INSTALL_BUN="bun install --ignore-scripts --silent"
 BENCH_INSTALL_DENO="deno install --quiet"
@@ -109,6 +111,7 @@ BENCH_COMMAND_BERRY="timeout $BENCH_TIMEOUT $BENCH_INSTALL_BERRY > $BENCH_OUTPUT
 BENCH_COMMAND_ZPM="timeout $BENCH_TIMEOUT $BENCH_INSTALL_ZPM > $BENCH_OUTPUT_FOLDER/zpm-output-\${HYPERFINE_ITERATION}.log 2>&1"
 BENCH_COMMAND_PNPM="timeout $BENCH_TIMEOUT $BENCH_INSTALL_PNPM > $BENCH_OUTPUT_FOLDER/pnpm-output-\${HYPERFINE_ITERATION}.log 2>&1"
 BENCH_COMMAND_PNPM11="timeout $BENCH_TIMEOUT $BENCH_INSTALL_PNPM11 > $BENCH_OUTPUT_FOLDER/pnpm11-output-\${HYPERFINE_ITERATION}.log 2>&1"
+BENCH_COMMAND_PACQUET="timeout $BENCH_TIMEOUT $BENCH_INSTALL_PACQUET > $BENCH_OUTPUT_FOLDER/pacquet-output-\${HYPERFINE_ITERATION}.log 2>&1"
 BENCH_COMMAND_VLT="timeout $BENCH_TIMEOUT $BENCH_INSTALL_VLT > $BENCH_OUTPUT_FOLDER/vlt-output-\${HYPERFINE_ITERATION}.log 2>&1"
 BENCH_COMMAND_BUN="timeout $BENCH_TIMEOUT $BENCH_INSTALL_BUN > $BENCH_OUTPUT_FOLDER/bun-output-\${HYPERFINE_ITERATION}.log 2>&1"
 BENCH_COMMAND_DENO="timeout $BENCH_TIMEOUT $BENCH_INSTALL_DENO > $BENCH_OUTPUT_FOLDER/deno-output-\${HYPERFINE_ITERATION}.log 2>&1"
@@ -145,7 +148,7 @@ collect_package_count() {
   ls -la "$BENCH_OUTPUT_FOLDER"
 
   # Prints the output of each install
-  for pm in npm yarn berry zpm pnpm pnpm11 vlt bun deno aube nx turbo vp node; do
+  for pm in npm yarn berry zpm pnpm pnpm11 pacquet vlt bun deno aube nx turbo vp node; do
     if echo "$BENCH_INCLUDE" | grep -qw "$pm"; then
       for i in {0..9}; do
         echo "-- Reading output of $pm install $i ---"
@@ -183,6 +186,7 @@ collect_process_count() {
     [zpm]="$BENCH_SETUP_ZPM"
     [pnpm]="$BENCH_SETUP_PNPM"
     [pnpm11]="$BENCH_SETUP_PNPM11"
+    [pacquet]="$BENCH_SETUP_PACQUET"
     [vlt]="$BENCH_SETUP_VLT"
     [bun]="$BENCH_SETUP_BUN"
     [deno]="$BENCH_SETUP_DENO"
@@ -195,6 +199,7 @@ collect_process_count() {
     [zpm]="$BENCH_INSTALL_ZPM"
     [pnpm]="$BENCH_INSTALL_PNPM"
     [pnpm11]="$BENCH_INSTALL_PNPM11"
+    [pacquet]="$BENCH_INSTALL_PACQUET"
     [vlt]="$BENCH_INSTALL_VLT"
     [bun]="$BENCH_INSTALL_BUN"
     [deno]="$BENCH_INSTALL_DENO"
@@ -207,13 +212,14 @@ collect_process_count() {
     [zpm]="$BENCH_INCLUDE_ZPM"
     [pnpm]="$BENCH_INCLUDE_PNPM"
     [pnpm11]="$BENCH_INCLUDE_PNPM11"
+    [pacquet]="$BENCH_INCLUDE_PACQUET"
     [vlt]="$BENCH_INCLUDE_VLT"
     [bun]="$BENCH_INCLUDE_BUN"
     [deno]="$BENCH_INCLUDE_DENO"
     [aube]="$BENCH_INCLUDE_AUBE"
   )
 
-  for pm in npm yarn berry zpm pnpm pnpm11 vlt bun deno aube; do
+  for pm in npm yarn berry zpm pnpm pnpm11 pacquet vlt bun deno aube; do
     if [ -n "${PM_INCLUDE[$pm]:-}" ]; then
       local prepare_cmd="$BENCH_PREPARE_BASE"
       local setup="${PM_SETUP[$pm]:-}"

--- a/scripts/variations/lockfile+node_modules.sh
+++ b/scripts/variations/lockfile+node_modules.sh
@@ -30,6 +30,8 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_PNPM:+--command-name="pnpm" "$BENCH_COMMAND_PNPM"} \
   ${BENCH_INCLUDE_PNPM11:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PNPM11")"} \
   ${BENCH_INCLUDE_PNPM11:+--command-name="pnpm11" "$BENCH_COMMAND_PNPM11"} \
+  ${BENCH_INCLUDE_PACQUET:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PACQUET")"} \
+  ${BENCH_INCLUDE_PACQUET:+--command-name="pacquet" "$BENCH_COMMAND_PACQUET"} \
   ${BENCH_INCLUDE_VLT:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_VLT")"} \
   ${BENCH_INCLUDE_VLT:+--command-name="vlt" "$BENCH_COMMAND_VLT"} \
   ${BENCH_INCLUDE_BUN:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_BUN")"} \

--- a/scripts/variations/lockfile.sh
+++ b/scripts/variations/lockfile.sh
@@ -30,6 +30,8 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_PNPM:+--command-name="pnpm" "$BENCH_COMMAND_PNPM"} \
   ${BENCH_INCLUDE_PNPM11:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PNPM11")"} \
   ${BENCH_INCLUDE_PNPM11:+--command-name="pnpm11" "$BENCH_COMMAND_PNPM11"} \
+  ${BENCH_INCLUDE_PACQUET:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PACQUET")"} \
+  ${BENCH_INCLUDE_PACQUET:+--command-name="pacquet" "$BENCH_COMMAND_PACQUET"} \
   ${BENCH_INCLUDE_VLT:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_VLT")"} \
   ${BENCH_INCLUDE_VLT:+--command-name="vlt" "$BENCH_COMMAND_VLT"} \
   ${BENCH_INCLUDE_BUN:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_BUN")"} \

--- a/scripts/variations/node_modules.sh
+++ b/scripts/variations/node_modules.sh
@@ -30,6 +30,8 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_PNPM:+--command-name="pnpm" "$BENCH_COMMAND_PNPM"} \
   ${BENCH_INCLUDE_PNPM11:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PNPM11")"} \
   ${BENCH_INCLUDE_PNPM11:+--command-name="pnpm11" "$BENCH_COMMAND_PNPM11"} \
+  ${BENCH_INCLUDE_PACQUET:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_PACQUET")"} \
+  ${BENCH_INCLUDE_PACQUET:+--command-name="pacquet" "$BENCH_COMMAND_PACQUET"} \
   ${BENCH_INCLUDE_VLT:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_VLT")"} \
   ${BENCH_INCLUDE_VLT:+--command-name="vlt" "$BENCH_COMMAND_VLT"} \
   ${BENCH_INCLUDE_BUN:+--prepare="$(append_setup "$BENCH_PREPARE_BASE" "$BENCH_SETUP_BUN")"} \


### PR DESCRIPTION
## Summary

### Part 1: Add pacquet as a new package manager

[pacquet](https://www.npmjs.com/package/pacquet) is the official pnpm rewrite in Rust (preview, v0.2.2-5). Added end-to-end following existing PM patterns:

- **`bench`** — added to `AVAILABLE_PMS`
- **`scripts/variations/common.sh`** — added `BENCH_COMMAND_PACQUET`, `BENCH_SETUP_PACQUET`, `BENCH_INCLUDE_PACQUET`, install command (`pacquet install`)
- **All install variation scripts** — clean, cache, lockfile, node_modules, and all combinations
- **`scripts/clean-helpers.sh`** — added `clean_pacquet_cache()` (shares pnpm store layout)
- **`scripts/setup.sh`** — install via `npm i -g pacquet@latest`, version logging
- **`.github/workflows/benchmark.yaml`** — added to default binaries list
- **`scripts/generate-chart.js`** — added pacquet color (`#d4740a`)
- **`scripts/collect-package-count.js`** / **`collect-process-count.js`** — added pacquet entries
- **App types** (`chart-data.ts`) — added `pacquet` to `PackageManager` type and all interfaces
- **App utils** (`utils.ts`, `get-icons.ts`, `use-history-data.ts`) — display name, icon (uses pnpm icon), leaderboard

> pacquet is excluded from build/build-cache/run variations since it's install-only (no script runner yet).

### Part 2: Unify pnpm variant naming/styling

Like the yarn family (yarn v1 / yarn berry / yarn zpm), pnpm variants now display as:

| Internal key | Display name | Color |
|---|---|---|
| `pnpm` | pnpm (v10) | `#f9ad00` (primary) |
| `pnpm11` | pnpm (v11) | `#e68a00` |
| `pacquet` | pnpm (pacquet) | `#d4740a` |

Internal keys remain unchanged for backward compatibility with existing chart data.

---

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>