### PR TITLE
fix: update vlt registry URL to new path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The installation tests we run today mimic a matrix of different variations (cold
 Registry benchmarking is available in the `registry-clean` and `registry-lockfile` variations.
 
 - `npm` (`https://registry.npmjs.org/`)
-- `vlt` (`https://registry.vlt.io/npm/`)
+- `vlt` (`https://registry.vlt.io/vlt/npm/`)
 - `aws` (CodeArtifact benchmark registry)
 
 Defaults:

--- a/scripts/registry/common.sh
+++ b/scripts/registry/common.sh
@@ -61,7 +61,7 @@ BENCH_NPM_INSTALL="npm install --prefer-online --no-audit --no-fund --no-update-
 
 # Registry definitions
 BENCH_REGISTRY_NPM_URL="https://registry.npmjs.org/"
-BENCH_REGISTRY_VLT_URL="https://registry.vlt.io/npm/"
+BENCH_REGISTRY_VLT_URL="https://registry.vlt.io/vlt/npm/"
 BENCH_REGISTRY_VLT_URL_NPMRC_KEY="${BENCH_REGISTRY_VLT_URL#http*://}"
 BENCH_REGISTRY_AWS_URL="https://vlt-451504312483.d.codeartifact.us-east-1.amazonaws.com/npm/code-artifact-benchmark-test/"
 BENCH_REGISTRY_AWS_NPMRC_KEY="${BENCH_REGISTRY_AWS_URL#http*://}"


### PR DESCRIPTION
Updates the vlt registry URL from `registry.vlt.io/npm/` to `registry.vlt.io/vlt/npm/` to match the new registry path.

### Changes
- `README.md` — updated URL in registry list
- `scripts/registry/common.sh` — updated `BENCH_REGISTRY_VLT_URL`

Co-authored-by: Evert Pot <me@evertpot.com>