### PR TITLE
fix: add || true to pnpm11 prepare in run and build variations

### DIFF
--- a/scripts/variations/build.sh
+++ b/scripts/variations/build.sh
@@ -68,7 +68,7 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_ZPM:+--command-name="zpm" "$BENCH_COMMAND_ZPM"} \
   ${BENCH_INCLUDE_PNPM:+--prepare="$BENCH_INSTALL_PREPARE_PNPM; bash $BENCH_SCRIPTS/clean-helpers.sh clean_build_output"} \
   ${BENCH_INCLUDE_PNPM:+--command-name="pnpm" "$BENCH_COMMAND_PNPM"} \
-  ${BENCH_INCLUDE_PNPM11:+--prepare="$BENCH_INSTALL_PREPARE_PNPM11; bash $BENCH_SCRIPTS/clean-helpers.sh clean_build_output"} \
+  ${BENCH_INCLUDE_PNPM11:+--prepare="$BENCH_INSTALL_PREPARE_PNPM11 || true; bash $BENCH_SCRIPTS/clean-helpers.sh clean_build_output"} \
   ${BENCH_INCLUDE_PNPM11:+--command-name="pnpm11" "$BENCH_COMMAND_PNPM11"} \
   ${BENCH_INCLUDE_VLT:+--prepare="$BENCH_INSTALL_PREPARE_VLT; bash $BENCH_SCRIPTS/clean-helpers.sh clean_build_output"} \
   ${BENCH_INCLUDE_VLT:+--command-name="vlt" "$BENCH_COMMAND_VLT"} \

--- a/scripts/variations/run.sh
+++ b/scripts/variations/run.sh
@@ -69,7 +69,7 @@ hyperfine --ignore-failure \
   ${BENCH_INCLUDE_ZPM:+--command-name="zpm" "$BENCH_COMMAND_ZPM"} \
   ${BENCH_INCLUDE_PNPM:+--prepare="$BENCH_INSTALL_PREPARE_PNPM"} \
   ${BENCH_INCLUDE_PNPM:+--command-name="pnpm" "$BENCH_COMMAND_PNPM"} \
-  ${BENCH_INCLUDE_PNPM11:+--prepare="$BENCH_INSTALL_PREPARE_PNPM11"} \
+  ${BENCH_INCLUDE_PNPM11:+--prepare="$BENCH_INSTALL_PREPARE_PNPM11 || true"} \
   ${BENCH_INCLUDE_PNPM11:+--command-name="pnpm11" "$BENCH_COMMAND_PNPM11"} \
   ${BENCH_INCLUDE_VLT:+--prepare="$BENCH_INSTALL_PREPARE_VLT"} \
   ${BENCH_INCLUDE_VLT:+--command-name="vlt" "$BENCH_COMMAND_VLT"} \


### PR DESCRIPTION
## Problem

The daily benchmark runs have been failing since **May 1** because `corepack pnpm@next-11 install` errors out during the `--prepare` step of the `run` variation. Since hyperfine aborts when a prepare command returns non-zero, the entire `Run Benchmarks (run, run)` job fails, which blocks `Process Results` and `Deploy Results`.

**Last successful daily run**: April 29  
**First failure**: April 30 (different job failed), May 1+ (`run, run` consistently failing)

## Fix

Add `|| true` to the pnpm11 `--prepare` commands in:
- `scripts/variations/run.sh`
- `scripts/variations/build.sh`

`build-cache.sh` already had `|| true` and was unaffected.

With `--ignore-failure` on the hyperfine invocation, this allows the suite to continue and record pnpm11 as a failed run rather than aborting all benchmarks.

## Root Cause

`corepack pnpm@next-11` install is failing (likely a transient issue with the `next-11` dist-tag or a breaking change in the latest pnpm 11 canary). This is the same pattern that required `|| true` for `aube` and `npm` prepares.