### PR TITLE
feat: use vlt registry for vlt CLI benchmarks

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -151,6 +151,7 @@ jobs:
       - name: Run Benchmarks variations
         env:
           CODEARTIFACT_AUTH_TOKEN: ${{ steps.aws.outputs.token }}
+          VLT_REGISTRY_URL: ${{ secrets.VLT_REGISTRY_URL }}
           VLT_REGISTRY_AUTH_TOKEN: ${{ secrets.VLT_REGISTRY_AUTH_TOKEN }}
           GH_REGISTRY: ${{ secrets.GH_REGISTRY }}
           GH_AUTH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}

--- a/scripts/variations/common.sh
+++ b/scripts/variations/common.sh
@@ -99,7 +99,16 @@ BENCH_INSTALL_BERRY="corepack yarn@latest install"
 BENCH_INSTALL_ZPM="yarn install --silent"
 BENCH_INSTALL_PNPM="corepack pnpm@latest install --ignore-scripts --silent"
 BENCH_INSTALL_PACQUET="pacquet install"
-BENCH_INSTALL_VLT="vlt install --view=silent"
+# vlt uses its own config (not .npmrc). When vlt registry credentials are
+# available, configure vlt to use the vlt registry via --registry flag and
+# VLT_REGISTRY / VLT_TOKEN env vars.
+if [ -n "${VLT_REGISTRY_URL:-}" ] && [ -n "${VLT_REGISTRY_AUTH_TOKEN:-}" ]; then
+  export VLT_REGISTRY="$VLT_REGISTRY_URL"
+  export VLT_TOKEN="$VLT_REGISTRY_AUTH_TOKEN"
+  BENCH_INSTALL_VLT="vlt install --registry=$VLT_REGISTRY_URL --view=silent"
+else
+  BENCH_INSTALL_VLT="vlt install --view=silent"
+fi
 BENCH_INSTALL_BUN="bun install --ignore-scripts --silent"
 BENCH_INSTALL_DENO="deno install --quiet"
 BENCH_INSTALL_AUBE="aube install --silent"


### PR DESCRIPTION
Configure only the **vlt CLI** to use the vlt registry when credentials are available. All other package managers continue using the default npm registry unchanged.

## Changes

- **`scripts/variations/common.sh`**: When `VLT_REGISTRY_URL` and `VLT_REGISTRY_AUTH_TOKEN` env vars are set, configure vlt to use the vlt registry via `--registry` flag and `VLT_REGISTRY`/`VLT_TOKEN` env vars. Other PMs are unaffected.
- **`.github/workflows/benchmark.yaml`**: Pass the `VLT_REGISTRY_URL` secret to the benchmark job environment.

## What was removed (vs the previous version of this PR)

- `scripts/setup-vlt-registry.sh` — no longer needed since only vlt uses the registry
- All `.npmrc` manipulation for other PMs
- The `BENCH_SETUP_VLT_REGISTRY`, `BENCH_USE_VLT_REGISTRY`, `BENCH_DEFAULT_REGISTRY_URL`, `BENCH_DEFAULT_REGISTRY_NPMRC_KEY` variables
- Berry/zpm `npmRegistryServer`/`npmAuthToken` config additions
- `clean_npmrc` in `clean_all()`

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>