### PR TITLE
fix: make aube installation non-fatal in setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -50,8 +50,12 @@ npm install -g npm@latest corepack@latest vlt@latest bun@latest deno@latest nx@l
 # Install Vite+ (vp) via npm (available as the `vite-plus` package)
 npm install -g vite-plus@latest
 
-# Install aube via npm (available as the `@endevco/aube` package)
-npm install -g @endevco/aube@latest
+# Install aube via npm (available as the `@endevco/aube` package).
+# Non-fatal: aube may not have a working binary for all platforms (e.g. arm64).
+# If it fails to install, the benchmark suite continues without aube.
+if ! npm install -g @endevco/aube@latest 2>/dev/null; then
+  echo "Warning: aube installation failed (may not support this platform) — skipping aube benchmarks"
+fi
 
 # Configure Package Managers
 echo "Configuring package managers..."


### PR DESCRIPTION
## Problem

All benchmark jobs on main have been failing since ~May 14 03:23 UTC. The root cause is `@endevco/aube@1.13.0` (published May 13 23:22 UTC) which removed `bin/aubr` and `bin/aubx` from its arm64 platform package but the installer (`installArchSpecificPackage.js`) still expects them, causing `npm install -g @endevco/aube@latest` to fail with:

```
npm error [@endevco/aube] preinstall failed: platform package bin "aubr" cannot be resolved:
ENOENT: no such file or directory, lstat '.../aube-linux-arm64/bin/aubr'
```

Since `setup.sh` runs with `set -e`, this kills the entire step — all 60+ benchmark matrix jobs fail before even reaching the benchmarks.

## Fix

Wrap the `@endevco/aube` install in `if !` so a broken aube release doesn't block the entire suite. If aube fails to install, a warning is logged and benchmarks continue with all other package managers.

This is a cherry-pick of 34f36372af from the `feat/vlt-registry-default` branch, which has already been verified to fix the issue (run #25835464935 succeeded with this change).

## Verification

- Last successful main run: May 13 11:09 UTC (aube 1.12.0 had `bin/aubr`)
- First failing main run: May 14 03:23 UTC (aube 1.13.x missing `bin/aubr`)
- Successful `feat/vlt-registry-default` run with this fix: May 14 01:03 UTC