### PR TITLE
fix: strip devEngines.packageManager in cleanup (fixes EBADDEVENGINES benchmark failures)

### DIFF
--- a/scripts/clean-helpers.sh
+++ b/scripts/clean-helpers.sh
@@ -136,9 +136,16 @@ clean_lockfiles() {
 
 # Function to clean package manager field from package.json
 clean_package_manager_field() {
-  echo "Removing packageManager field from package.json..."
+  echo "Removing packageManager / devEngines.packageManager from package.json..."
   if command -v vlt &> /dev/null; then
     vlt pkg rm packageManager
+    # Recent corepack/yarn auto-pin a devEngines.packageManager entry (e.g.
+    # yarn) into package.json. npm and pnpm enforce devEngines and refuse to
+    # run any command when it doesn't match (EBADDEVENGINES), which breaks
+    # every benchmark that isn't that package manager. Strip it so each PM can
+    # run. vlt is used because it doesn't enforce devEngines, whereas npm/pnpm
+    # would themselves fail on the field we're trying to remove.
+    vlt pkg rm devEngines.packageManager
   fi
 }
 
@@ -213,17 +220,25 @@ clean_git() {
 clean_workspace_protocol() {
   echo "Restoring package.json files (undo workspace: protocol changes)..."
   if command -v git &> /dev/null && git rev-parse --git-dir > /dev/null 2>&1; then
-    git checkout -- packages/ package.json 2>/dev/null || true
+    # Restore each path independently. A single `git checkout -- packages/
+    # package.json` fails as a whole when `packages/` does not exist (most
+    # fixtures are not monorepos), leaving package.json un-restored.
+    git checkout -- package.json 2>/dev/null || true
+    [ -e packages ] && git checkout -- packages/ 2>/dev/null || true
   fi
 }
 
 clean_all() {
   clean_node_modules
   clean_lockfiles
-  clean_package_manager_field
   clean_package_manager_files
   clean_workspace_protocol
   clean_all_cache
+  # Strip packageManager / devEngines.packageManager AFTER the cache cleans:
+  # the corepack-based cache cleans in clean_all_cache can re-pin a
+  # devEngines.packageManager entry into package.json, so this must run last
+  # to guarantee a neutral manifest before the next benchmark.
+  clean_package_manager_field
   clean_build_files
   clean_build_output
   echo "Cleanup completed successfully!"


### PR DESCRIPTION
## Problem

The scheduled **Package Manager Benchmarks** workflow has failed every run since **Jun 18**. The same 5 jobs fail deterministically:

- `next` × `registry-clean`, `registry-lockfile`
- `babylon` × `registry-clean`, `registry-lockfile`
- `run` × `run`

All die with hyperfine's `Error: The preparation command terminated with a non-zero exit code.`

## Root cause

A diagnostic run (un-swallowing the hyperfine `--prepare` output) showed the failing command is `npm config set registry … --location=project`, with the real error hidden by `loglevel silent`:

```
npm error code EBADDEVENGINES
npm error EBADDEVENGINES Invalid name "yarn" does not match "npm" for "packageManager"
npm error EBADDEVENGINES   required: { name: 'yarn', version: '4.17.0', onFail: 'download' }
```

Recent **corepack/yarn auto-pin a `devEngines.packageManager` (yarn) entry** into `package.json` for the only two fixtures that ship a `.yarnrc.yml` — `next` and `babylon` — during `clean_all`'s `corepack yarn@…` cache-clean steps. **npm and pnpm enforce `devEngines`** and refuse to run *any* command (even `npm config get`) when it doesn't match, so the npm-based registry benchmarks and the pnpm step of the `run` benchmark abort at their first prepare.

Nothing changed in this repo (last commit Jun 10) — `setup.sh` installs PMs at `@latest`, so the trigger was an upstream tool update. The cleanup only stripped `packageManager`, never `devEngines.packageManager`, so the pin survived into the benchmark.

## Fix

- **`clean_package_manager_field`**: also `vlt pkg rm devEngines.packageManager`. `vlt` is used because it doesn't enforce `devEngines`, whereas npm/pnpm would themselves fail on the field we're removing.
- **`clean_all`**: run `clean_package_manager_field` **after** `clean_all_cache`, since the corepack cache cleans are what re-pin the field.
- **`clean_workspace_protocol`**: restore `package.json` and `packages/` with independent `git checkout` calls — the combined pathspec failed as a whole when `packages/` was absent (non-monorepo fixtures), leaving `package.json` un-restored.

## Verification

Reproduced the failure locally (`npm`/`pnpm` exit 1 with the field present) and confirmed the patched `clean_all` strips it and restores `npm config set` to exit 0. The diagnostic CI run also confirmed `run` passes when no yarn/berry step precedes pnpm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)