### PR TITLE
fix: strip devEngines.packageManager in registry-lockfile prepare (follow-up to #118)

### DIFF
--- a/scripts/variations/registry-lockfile.sh
+++ b/scripts/variations/registry-lockfile.sh
@@ -4,8 +4,12 @@ set -Eeuxo pipefail
 # Load registry common variables
 source "$1/registry/common.sh"
 
-# Prepare command base for each run: clean cache, node_modules, pm files, but keep lockfile
-BENCH_PREPARE_BASE="sleep 1; bash $BENCH_SCRIPTS/clean-helpers.sh clean_all_cache clean_node_modules clean_package_manager_files clean_npmrc"
+# Prepare command base for each run: clean cache, node_modules, pm files, but keep lockfile.
+# clean_package_manager_field runs AFTER clean_all_cache: the corepack-based yarn
+# cache cleans re-pin a devEngines.packageManager entry into package.json, which
+# makes the subsequent `npm config set` prepare step fail with EBADDEVENGINES.
+# (It only touches package.json, never the lockfile, so the lockfile is preserved.)
+BENCH_PREPARE_BASE="sleep 1; bash $BENCH_SCRIPTS/clean-helpers.sh clean_all_cache clean_package_manager_field clean_node_modules clean_package_manager_files clean_npmrc"
 
 # Run the benchmark suite
 # When running a lockfile benchmark, we keep the lockfile between runs


### PR DESCRIPTION
Follow-up to #118. After that merged, the first push run on `main` showed `run` and `registry-clean` recover, but **`registry-lockfile` (next, babylon) still failed** at the npm prepare with `EBADDEVENGINES`.

Cause: `registry-lockfile.sh`'s per-run prepare cleans caches with the granular helpers (`clean_all_cache clean_node_modules clean_package_manager_files clean_npmrc`) and — unlike `registry-clean.sh`, which uses `clean_all` — never ran `clean_package_manager_field`. So the `corepack yarn` cache cleans inside `clean_all_cache` re-pinned `devEngines.packageManager`, and the following `npm config set … --location=project` prepare step aborted.

Fix: add `clean_package_manager_field` immediately after `clean_all_cache` in the prepare base. It only edits `package.json` (strips `packageManager` / `devEngines.packageManager`), so the lockfile this variation deliberately keeps is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)