### PR TITLE
fix(ci): reduce warmup/runs for registry variations to prevent timeout

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -132,22 +132,34 @@ jobs:
             --output text)
           echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
           echo "token=$CODEARTIFACT_AUTH_TOKEN" >> "$GITHUB_OUTPUT"
-      - name: Tune settings for heavy fixtures
+      - name: Tune benchmark settings
         id: tune
         run: |
+          # Start with defaults
+          warmup="$BENCH_WARMUP"
+          runs="$BENCH_RUNS"
+
           # Heavy fixtures (large, babylon) get reduced warmup/runs to keep
           # individual jobs under the timeout while still producing useful data.
           case "${{ matrix.fixture }}" in
             large|babylon)
-              echo "warmup=1" >> "$GITHUB_OUTPUT"
-              echo "runs=3" >> "$GITHUB_OUTPUT"
-              echo "Heavy fixture detected — using warmup=1, runs=3"
-              ;;
-            *)
-              echo "warmup=$BENCH_WARMUP" >> "$GITHUB_OUTPUT"
-              echo "runs=$BENCH_RUNS" >> "$GITHUB_OUTPUT"
+              warmup=1
+              runs=3
+              echo "Heavy fixture detected — using warmup=$warmup, runs=$runs"
               ;;
           esac
+
+          # Registry variations also get reduced runs (6 registries × iterations must fit in 90min)
+          case "${{ matrix.variation }}" in
+            registry-*)
+              warmup=1
+              runs=3
+              echo "Registry variation detected — using warmup=$warmup, runs=$runs"
+              ;;
+          esac
+
+          echo "warmup=$warmup" >> "$GITHUB_OUTPUT"
+          echo "runs=$runs" >> "$GITHUB_OUTPUT"
       - name: Run Benchmarks variations
         env:
           CODEARTIFACT_AUTH_TOKEN: ${{ steps.aws.outputs.token }}


### PR DESCRIPTION
## Problem

Registry benchmark jobs (`registry-clean`, `registry-lockfile`) are timing out at the 90min job limit. With 6 registries now (npm, vlt, aws, cloudsmith, github, jfrog), each running 5 runs + 2 warmup = 42 total hyperfine iterations per job, which takes ~119min.

## Fix

Extended the **Tune benchmark settings** step (formerly "Tune settings for heavy fixtures") to also detect `registry-*` variations and reduce warmup/runs to 1/3.

The step now:
1. Starts with default `BENCH_WARMUP` / `BENCH_RUNS` values
2. Overrides to warmup=1, runs=3 for heavy fixtures (`large`, `babylon`)
3. Overrides to warmup=1, runs=3 for registry variations (`registry-*`)

This brings estimated runtime from ~119min down to ~51min, well within the 90min job limit.

### Changes
- `.github/workflows/benchmark.yaml`: Restructured tune step to handle both fixture and variation overrides

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>