### PR TITLE
fix: replace pacquet with pnpm 12 alpha + fix aube installation

### DIFF
--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -220,11 +220,12 @@ export const calculateLeaderboard = (
     effectiveRoute === "task-runners"
       ? allPMs // task runners may include node, nx, turbo, etc.
       : effectiveRoute === "registries"
-        ? allPMs.filter((pm: string) =>
-            // Registry variations use a different set of PMs
-            chartData.registryChartData?.packageManagers?.includes(
-              pm as PackageManager,
-            ) ?? false,
+        ? allPMs.filter(
+            (pm: string) =>
+              // Registry variations use a different set of PMs
+              chartData.registryChartData?.packageManagers?.includes(
+                pm as PackageManager,
+              ) ?? false,
           )
         : allPMs.filter((pm: string) =>
             [
@@ -260,7 +261,8 @@ export const calculateLeaderboard = (
   // Determine which variations and data source to use
   let variationsToUse: Variation[];
   const usePerPackageData =
-    effectiveRoute === "package-managers" && !isRegistryVariation(specificVariation ?? "");
+    effectiveRoute === "package-managers" &&
+    !isRegistryVariation(specificVariation ?? "");
 
   if (specificVariation && specificVariation !== "average") {
     variationsToUse = [specificVariation];
@@ -329,9 +331,7 @@ export const calculateLeaderboard = (
       });
 
       // Determine the winner (lowest time, only among successful PMs)
-      const successfulTimes = times.filter(
-        (t) => !dnfPMs.includes(t.pm),
-      );
+      const successfulTimes = times.filter((t) => !dnfPMs.includes(t.pm));
       successfulTimes.sort((a, b) => a.time - b.time);
       if (successfulTimes.length > 0) {
         const winnerStats = packageManagerStats[successfulTimes[0].pm];
@@ -509,14 +509,13 @@ export function getPackageManagerDisplayName(
   if (options?.isRegistryVariation) {
     if (packageManager === "npm") return "registry.npmjs.org";
     if (packageManager === "vlt") return "registry.vlt.io";
-    if (packageManager === "aws")
-      return "codeartifact.us-east-1.amazonaws.com";
+    if (packageManager === "aws") return "codeartifact.us-east-1.amazonaws.com";
     if (packageManager === "cloudsmith") return "npm.cloudsmith.io";
     if (packageManager === "github") return "npm.pkg.github.com";
     if (packageManager === "jfrog") return "jfrog.io";
   }
   if (packageManager === "pnpm") return "pnpm";
-  if (packageManager === "pacquet") return "pnpm (pacquet)";
+  if (packageManager === "pacquet") return "pnpm (v12)";
   if (packageManager === "berry") return "yarn (berry)";
   if (packageManager === "zpm") return "yarn (zpm)";
   if (packageManager === "turbo") return "turborepo";

--- a/scripts/clean-helpers.sh
+++ b/scripts/clean-helpers.sh
@@ -48,11 +48,11 @@ clean_pnpm_cache() {
   safe_remove "$HOME/.local/share/pnpm/store"
 }
 
-# Function to safely clean pacquet cache
-# pacquet shares pnpm's content-addressable store layout
+# Function to safely clean pacquet (pnpm 12) cache
+# pnpm 12 shares pnpm's content-addressable store layout
 clean_pacquet_cache() {
-  if command -v pacquet &> /dev/null; then
-    # pacquet uses the same store path as pnpm; the parent dirs are cleaned
+  if [ -x "/tmp/pnpm12/node_modules/.bin/pnpm" ]; then
+    # pnpm 12 uses the same store path as pnpm; the parent dirs are cleaned
     # by clean_pnpm_cache, but if called in isolation we still handle them.
     safe_remove "$HOME/.cache/pnpm"
     safe_remove "$HOME/.local/share/pnpm/store"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -45,16 +45,31 @@ echo "hyperfine: $HYPERFINE_VERSION"
 
 # Install Node.js package managers and tools
 echo "Installing package managers and tools..."
-npm install -g npm@latest corepack@latest vlt@latest bun@latest deno@latest nx@latest turbo@latest pacquet@latest
+npm install -g npm@latest corepack@latest vlt@latest bun@latest deno@latest nx@latest turbo@latest
 
 # Install Vite+ (vp) via npm (available as the `vite-plus` package)
 npm install -g vite-plus@latest
 
+# Install pnpm 12 alpha (pacquet engine) to a dedicated prefix so it doesn't
+# conflict with the corepack-managed pnpm@latest used by the pnpm benchmark.
+npm install pnpm@next-12 --prefix /tmp/pnpm12
+
 # Install aube via npm (available as the `@endevco/aube` package).
 # Non-fatal: aube may not have a working binary for all platforms (e.g. arm64).
 # If it fails to install, the benchmark suite continues without aube.
-if ! npm install -g @endevco/aube@latest 2>/dev/null; then
+if ! npm install -g @endevco/aube@latest; then
   echo "Warning: aube installation failed (may not support this platform) — skipping aube benchmarks"
+fi
+
+# Verify aube binary is actually available (install may succeed but produce no binary)
+if ! command -v aube &>/dev/null; then
+  echo "Warning: aube binary not available after installation — excluding from benchmarks"
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    BENCH_INCLUDE="${BENCH_INCLUDE:-npm,yarn,berry,zpm,pnpm,pacquet,vlt,bun,deno,aube,nx,turbo,vp,node}"
+    BENCH_INCLUDE="${BENCH_INCLUDE//,aube/}"
+    BENCH_INCLUDE="${BENCH_INCLUDE//aube,/}"
+    echo "BENCH_INCLUDE=$BENCH_INCLUDE" >> "$GITHUB_ENV"
+  fi
 fi
 
 # Configure Package Managers
@@ -78,7 +93,7 @@ YARN_VERSION="$(corepack yarn@1 -v)"
 BERRY_VERSION="$(corepack yarn@latest -v)"
 ZPM_VERSION="$(curl https://repo.yarnpkg.com/channels/default/canary)"
 PNPM_VERSION="$(corepack pnpm@latest -v)"
-PACQUET_VERSION="$(pacquet --version 2>/dev/null | head -1 | grep -Eo '[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?' | head -1 || echo "unknown")"
+PACQUET_VERSION="$(/tmp/pnpm12/node_modules/.bin/pnpm --version 2>/dev/null || echo "unknown")"
 BUN_VERSION="$(bun -v)"
 DENO_VERSION="$(npm view deno@latest version)"
 NX_VERSION="$(npm view nx@latest version)"

--- a/scripts/variations/common.sh
+++ b/scripts/variations/common.sh
@@ -98,7 +98,7 @@ BENCH_INSTALL_YARN="corepack yarn@1 install --ignore-scripts --silent"
 BENCH_INSTALL_BERRY="corepack yarn@latest install"
 BENCH_INSTALL_ZPM="yarn install --silent"
 BENCH_INSTALL_PNPM="corepack pnpm@latest install --ignore-scripts --silent"
-BENCH_INSTALL_PACQUET="pacquet install"
+BENCH_INSTALL_PACQUET="/tmp/pnpm12/node_modules/.bin/pnpm install --ignore-scripts --silent"
 # vlt uses its own config (not .npmrc). When vlt registry credentials are
 # available, configure vlt to use the vlt registry via --registry flag and
 # VLT_REGISTRY / VLT_TOKEN env vars.


### PR DESCRIPTION
## Summary

### Fix 1: Replace standalone `pacquet` with `pnpm@next-12`

The standalone `pacquet` npm package was failing benchmarks because recent versions introduced pnpm's `approve-builds` check (`ERR_PNPM_IGNORED_BUILDS`), causing exit code 1 on every run. This PR switches to `pnpm@next-12` (v12 alpha) which uses the pacquet Rust engine under the hood.

**Changes:**
- **`scripts/setup.sh`**: Remove `pacquet@latest` from global installs; install `pnpm@next-12` to `/tmp/pnpm12` prefix to avoid conflicting with corepack-managed `pnpm@latest`
- **`scripts/variations/common.sh`**: Update `BENCH_INSTALL_PACQUET` to use `/tmp/pnpm12/node_modules/.bin/pnpm install --ignore-scripts --silent`
- **`scripts/clean-helpers.sh`**: Update `clean_pacquet_cache()` to check for pnpm 12 binary at dedicated prefix
- **`app/src/lib/utils.ts`**: Update display name from `"pnpm (pacquet)"` to `"pnpm (v12)"`

The internal benchmark identifier stays as `pacquet` for chart/data backward compatibility.

### Fix 2: Fix aube installation

`npm install -g @endevco/aube@latest 2>/dev/null` was silently failing, and the benchmark would try to run `aube` (exit code 127, 0.001s timing).

**Changes in `scripts/setup.sh`:**
- Remove `2>/dev/null` stderr suppression so errors are visible
- Add post-install check: if `aube` binary is not available, auto-exclude it from `BENCH_INCLUDE` via `$GITHUB_ENV`

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>