### PR TITLE
feat: make registries the default/first page

### DIFF
--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -12,7 +12,7 @@ import { YAxisProvider } from "@/contexts/y-axis-context";
 import { Toaster } from "@/components/ui/sonner";
 import { useChartData } from "@/hooks/use-chart-data";
 import { useHistoryData } from "@/hooks/use-history-data";
-import { getAllFixtures, sortVariations } from "@/lib/utils";
+import { getAllFixtures } from "@/lib/utils";
 
 const App = () => {
   const { chartData, loading, error } = useChartData();
@@ -26,11 +26,7 @@ const App = () => {
 
   useEffect(() => {
     if (chartData && location.pathname === "/") {
-      const sortedVariations = sortVariations([
-        ...chartData.chartData.variations,
-      ]);
-      const firstVariation = sortedVariations[0];
-      navigate(`/package-managers/${firstVariation}`, { replace: true });
+      navigate("/registries", { replace: true });
     }
   }, [chartData, location.pathname]);
 

--- a/app/src/components/header.tsx
+++ b/app/src/components/header.tsx
@@ -3,7 +3,13 @@ import { useLocation, NavLink } from "react-router";
 import { PackageManagerFilter } from "@/components/package-manager-filter";
 import { FixtureFilter } from "@/components/fixture-filter";
 import { VariationDropdown } from "@/components/variation-dropdown";
-import { Benchmarks, Github, Package, StopWatch, Database } from "@/components/icons";
+import {
+  Benchmarks,
+  Github,
+  Package,
+  StopWatch,
+  Database,
+} from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { format } from "date-fns";
 import {
@@ -114,6 +120,11 @@ const HeaderNavigation = forwardRef<HTMLDivElement, ComponentProps<"div">>(
 
     const navigationOptions: NavigationOption[] = [
       {
+        label: "Registries",
+        href: "registries",
+        icon: Database,
+      },
+      {
         label: "Package Managers",
         href: "package-managers",
         icon: Package,
@@ -122,11 +133,6 @@ const HeaderNavigation = forwardRef<HTMLDivElement, ComponentProps<"div">>(
         label: "Task Runners",
         href: "task-runners",
         icon: StopWatch,
-      },
-      {
-        label: "Registries",
-        href: "registries",
-        icon: Database,
       },
     ];
 
@@ -176,7 +182,7 @@ const HeaderNavigation = forwardRef<HTMLDivElement, ComponentProps<"div">>(
             <FixtureFilter fixtures={fixtures} />
             <VariationDropdown
               currentVariation={currentVariation ?? "average"}
-              baseRoute={location.pathname.split("/")[1] || "package-managers"}
+              baseRoute={location.pathname.split("/")[1] || "registries"}
               sortedVariations={(() => {
                 const baseRoute = location.pathname.split("/")[1];
                 const categories = getVariationCategories(
@@ -318,10 +324,12 @@ const LeaderBoardItem = ({
       : `${averageTime.toFixed(2)}s`;
 
   return (
-    <div className={cn(
-      "relative flex bg-card items-center gap-2.5 px-3 py-2 rounded-lg border flex-shrink-0 whitespace-nowrap min-w-[120px]",
-      isBaseline ? "border-dashed border-border" : "border-border/50",
-    )}>
+    <div
+      className={cn(
+        "relative flex bg-card items-center gap-2.5 px-3 py-2 rounded-lg border flex-shrink-0 whitespace-nowrap min-w-[120px]",
+        isBaseline ? "border-dashed border-border" : "border-border/50",
+      )}
+    >
       <div className="text-lg text-muted-foreground font-mono font-medium flex-shrink-0">
         {rank}
       </div>
@@ -331,7 +339,10 @@ const LeaderBoardItem = ({
           {Icon && (
             <Icon
               size={28}
-              className={cn((packageManager === "vlt" || packageManager === "github") && "dark:text-white")}
+              className={cn(
+                (packageManager === "vlt" || packageManager === "github") &&
+                  "dark:text-white",
+              )}
             />
           )}
         </div>
@@ -361,8 +372,7 @@ const HeaderLeaderboard = forwardRef<HTMLDivElement, ComponentProps<"div">>(
     const isRegistryRoute = baseRoute === "registries";
 
     // Determine the unit label based on route
-    const unit =
-      baseRoute === "package-managers" ? "ms/pkg" : "s";
+    const unit = baseRoute === "package-managers" ? "ms/pkg" : "s";
 
     const leaderboard = useMemo(() => {
       if (chartData && currentVariation) {
@@ -376,7 +386,13 @@ const HeaderLeaderboard = forwardRef<HTMLDivElement, ComponentProps<"div">>(
           enabledPackageManagers.has(item.packageManager),
         );
       }
-    }, [chartData, enabledPackageManagers, enabledFixtures, currentVariation, baseRoute]);
+    }, [
+      chartData,
+      enabledPackageManagers,
+      enabledFixtures,
+      currentVariation,
+      baseRoute,
+    ]);
 
     if (leaderboard && leaderboard.length === 0) return null;
 
@@ -391,7 +407,10 @@ const HeaderLeaderboard = forwardRef<HTMLDivElement, ComponentProps<"div">>(
                 averageTime={item.averageTime}
                 packageManager={item.packageManager}
                 unit={unit}
-                isBaseline={isBaselinePackageManager(item.packageManager, isRegistryRoute)}
+                isBaseline={isBaselinePackageManager(
+                  item.packageManager,
+                  isRegistryRoute,
+                )}
               />
             ))}
         </div>

--- a/app/src/components/share-button.tsx
+++ b/app/src/components/share-button.tsx
@@ -56,7 +56,7 @@ export const ShareButton = ({
 
   const handleShare = async () => {
     // Extract the base route (package-managers, task-runners, registries) from the current path
-    const baseRoute = location.pathname.split("/")[1] || "package-managers";
+    const baseRoute = location.pathname.split("/")[1] || "registries";
     const deepLink = createDeepLink(baseRoute, variation, section, fixture);
     const url = `${window.location.origin}${window.location.pathname}#${deepLink}`;
 

--- a/app/src/components/variation-dropdown.tsx
+++ b/app/src/components/variation-dropdown.tsx
@@ -28,7 +28,7 @@ export const VariationDropdown = ({
   const navigate = useNavigate();
   const location = useLocation();
   const resolvedRoute =
-    baseRoute || location.pathname.split("/")[1] || "package-managers";
+    baseRoute || location.pathname.split("/")[1] || "registries";
   const dropdownLabel = dropdownLabels[resolvedRoute] || "Fixture";
 
   return (
@@ -58,8 +58,7 @@ export const VariationDropdown = ({
           <DropdownMenuItem
             key={variation}
             onClick={() => {
-              const base =
-                location.pathname.split("/")[1] || "package-managers";
+              const base = location.pathname.split("/")[1] || "registries";
               navigate(`/${base}/${variation}`);
             }}
           >

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -212,7 +212,7 @@ export const calculateLeaderboard = (
   enabledFixtures?: Set<Fixture>,
 ): RankingData[] => {
   const categories = getVariationCategories(chartData.chartData.variations);
-  const effectiveRoute = route ?? "package-managers";
+  const effectiveRoute = route ?? "registries";
 
   // Determine which package managers to use based on route
   const allPMs = chartData.chartData.packageManagers;

--- a/app/src/routes.tsx
+++ b/app/src/routes.tsx
@@ -41,7 +41,7 @@ export const routes: RouteObject[] = [
   {
     path: "/",
     element: <App />,
-    children: [packageManagerRoutes, taskRunnerRoutes, registryRoutes],
+    children: [registryRoutes, packageManagerRoutes, taskRunnerRoutes],
   },
 ];
 


### PR DESCRIPTION
## Summary

Makes registries the default landing page and reorders navigation so registries appears first.

### Changes

- **Header navigation order**: Registries | Package Managers | Task Runners (was: Package Managers | Task Runners | Registries)
- **Default route**: Root URL `/` now redirects to `/registries` → `/registries/registry-clean` instead of `/package-managers/...`
- **Fallback defaults**: Updated all fallback route defaults from `package-managers` to `registries` across header, share button, variation dropdown, and leaderboard calculation
- **Route ordering**: Reordered route children to put registry routes first

### Files changed

- `app/src/app.tsx` — root redirect now goes to `/registries`, removed unused `sortVariations` import
- `app/src/routes.tsx` — reordered route children: registries first
- `app/src/components/header.tsx` — reordered nav options, updated fallback default
- `app/src/components/share-button.tsx` — updated fallback default
- `app/src/components/variation-dropdown.tsx` — updated fallback defaults
- `app/src/lib/utils.ts` — updated `calculateLeaderboard` default route

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>