### PR TITLE
fix: use Cloudsmith brand blue (#2C5BB4) for icon fill

### DIFF
--- a/app/src/components/icons/cloudsmith.tsx
+++ b/app/src/components/icons/cloudsmith.tsx
@@ -5,7 +5,7 @@ export const Cloudsmith = createLucideIcon("Cloudsmith", [
     "path",
     {
       d: "m23.99 10.67v2.67l-10.66 10.66h-2.67l-10.66-10.66v-2.67l10.66-10.66h2.67zm-5.74 1.33c0-3.46-2.80-6.26-6.26-6.26-3.46 0-6.26 2.80-6.26 6.26 0 3.46 2.80 6.26 6.26 6.26 3.46 0 6.26-2.80 6.26-6.26z",
-      fill: "currentColor",
+      fill: "#2C5BB4",
       fillRule: "evenodd",
       key: "1",
       strokeWidth: "0",


### PR DESCRIPTION
Change the Cloudsmith icon fill from `currentColor` to `#2C5BB4` (Cloudsmith brand blue), matching the pattern used by the JFrog icon which hardcodes its brand color (`#40BE46`).

This is the same blue used for the Cloudsmith benchmark chart bars (see `scripts/generate-chart.js` and `app/src/components/history-chart.tsx`).

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>