### PR TITLE
feat: add average variation for registries and task runners

### DIFF
--- a/app/src/components/variation/index.tsx
+++ b/app/src/components/variation/index.tsx
@@ -1,4 +1,4 @@
-import { useParams, useOutletContext } from "react-router";
+import { useParams, useOutletContext, useLocation } from "react-router";
 import { useEffect } from "react";
 import { isValidVariation } from "@/types/chart-data";
 import { ERROR_MESSAGES } from "@/constants";
@@ -19,6 +19,7 @@ import {
   getAvailablePackageManagersFromProcessCount,
   isTaskExecutionVariation,
   isRegistryVariation,
+  isAverageVariation,
 } from "@/lib/utils";
 
 import { HistoryChart } from "@/components/history-chart";
@@ -42,6 +43,8 @@ export const VariationPage = () => {
     fixture?: string;
   }>();
   const { chartData, historyData } = useOutletContext<OutletContext>();
+  const location = useLocation();
+  const baseRoute = location.pathname.split("/")[1] || "registries";
 
   // Call hooks before any early returns to comply with Rules of Hooks
   const {
@@ -87,9 +90,20 @@ export const VariationPage = () => {
     );
   }
 
-  const totalVariationData = chartData.chartData.data[variation as Variation];
+  // For "average" variation, use route-specific average data
+  const isAverage = isAverageVariation(variation as string);
+  const totalVariationData =
+    isAverage && baseRoute === "task-runners"
+      ? (chartData.taskRunnerAverageData ?? [])
+      : isAverage && baseRoute === "registries"
+        ? (chartData.registryAverageData ?? [])
+        : chartData.chartData.data[variation as Variation];
   const perPackageVariationData =
-    chartData.perPackageCountChartData.data[variation as Variation];
+    isAverage && baseRoute === "task-runners"
+      ? (chartData.taskRunnerAveragePerPackageData ?? [])
+      : isAverage && baseRoute === "registries"
+        ? (chartData.registryAveragePerPackageData ?? [])
+        : chartData.perPackageCountChartData.data[variation as Variation];
   const allPackageManagers = chartData.chartData.packageManagers;
   const colors = chartData.chartData.colors;
 
@@ -144,8 +158,13 @@ export const VariationPage = () => {
     );
 
   // Check if this is a task execution variation or registry variation
-  const isTaskExecution = isTaskExecutionVariation(variation as string);
-  const isRegistry = isRegistryVariation(variation as string);
+  // For "average", determine from the route context
+  const isTaskExecution =
+    isTaskExecutionVariation(variation as string) ||
+    (isAverage && baseRoute === "task-runners");
+  const isRegistry =
+    isRegistryVariation(variation as string) ||
+    (isAverage && baseRoute === "registries");
 
   // Dynamic titles and section IDs based on variation type
   const titles = isTaskExecution

--- a/app/src/hooks/use-chart-data.ts
+++ b/app/src/hooks/use-chart-data.ts
@@ -141,7 +141,7 @@ export const useChartData = (): UseChartDataReturn => {
 
       const normalizedChartData = applyDnfFallbacks(chartData);
 
-      // Calculate average data for both total and per-package
+      // Calculate average data for both total and per-package (package managers)
       const averageTotalData = calculateAverageVariationData(
         normalizedChartData,
         false,
@@ -150,6 +150,47 @@ export const useChartData = (): UseChartDataReturn => {
         normalizedChartData,
         true,
       );
+
+      // Calculate task runner average
+      const taskRunnerVariationNames = ["build", "build-cache", "run"];
+      const taskRunnerAverageTotalData = calculateAverageVariationData(
+        normalizedChartData,
+        false,
+        { variationNames: taskRunnerVariationNames },
+      );
+      const taskRunnerAveragePerPackageData = calculateAverageVariationData(
+        normalizedChartData,
+        true,
+        { variationNames: taskRunnerVariationNames },
+      );
+
+      // Calculate registry average
+      const registryVariationNames = ["registry-clean", "registry-lockfile"];
+      const registryDataSource = normalizedChartData.registryChartData;
+      const registryPerPackageSource =
+        normalizedChartData.registryPerPackageCountChartData;
+      const registryPackageManagers =
+        registryDataSource?.packageManagers ?? [];
+      const registryAverageTotalData = registryDataSource
+        ? calculateAverageVariationData(normalizedChartData, false, {
+            variationNames: registryVariationNames,
+            dataSource: registryDataSource.data as Record<
+              string,
+              FixtureResult[]
+            >,
+            packageManagers: registryPackageManagers,
+          })
+        : [];
+      const registryAveragePerPackageData = registryPerPackageSource
+        ? calculateAverageVariationData(normalizedChartData, true, {
+            variationNames: registryVariationNames,
+            dataSource: registryPerPackageSource.data as Record<
+              string,
+              FixtureResult[]
+            >,
+            packageManagers: registryPackageManagers,
+          })
+        : registryAverageTotalData;
 
       // Add "average" to variations list if not already present (typesafe)
       const averageVariation: Variation = "average";
@@ -223,6 +264,10 @@ export const useChartData = (): UseChartDataReturn => {
           packageManagers: allPackageManagers,
           colors: allColors,
         },
+        taskRunnerAverageData: taskRunnerAverageTotalData,
+        taskRunnerAveragePerPackageData: taskRunnerAveragePerPackageData,
+        registryAverageData: registryAverageTotalData,
+        registryAveragePerPackageData: registryAveragePerPackageData,
       };
 
       setChartData(combinedData);

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -35,6 +35,11 @@ export const isAverageVariation = (variation: string): boolean => {
 export const calculateAverageVariationData = (
   chartData: BenchmarkChartData,
   isPerPackage: boolean = false,
+  options?: {
+    variationNames?: string[];
+    dataSource?: Record<string, FixtureResult[]>;
+    packageManagers?: PackageManager[];
+  },
 ): FixtureResult[] => {
   type FillKey = Extract<keyof PackageManagerData, `${PackageManager}_fill`>;
   type StddevKey = Extract<
@@ -43,26 +48,35 @@ export const calculateAverageVariationData = (
   >;
   type CountKey = Extract<keyof PackageManagerData, `${PackageManager}_count`>;
   type DnfKey = Extract<keyof PackageManagerData, `${PackageManager}_dnf`>;
-  const dataSource = isPerPackage
+
+  const defaultDataSource = isPerPackage
     ? chartData.perPackageCountChartData.data
     : chartData.chartData.data;
+  const dataSource =
+    (options?.dataSource as Record<Variation, FixtureResult[]>) ??
+    defaultDataSource;
 
-  // Get package management variations (excluding "run" and "average")
-  const packageManagementVariations = [
-    "clean",
-    "node_modules",
-    "cache",
-    "cache+node_modules",
-    "cache+lockfile",
-    "cache+lockfile+node_modules",
-    "lockfile",
-    "lockfile+node_modules",
-  ].filter((v) => dataSource[v as Variation]);
+  // Default to package management variations for backward compatibility
+  const variationNames = (
+    options?.variationNames ?? [
+      "clean",
+      "node_modules",
+      "cache",
+      "cache+node_modules",
+      "cache+lockfile",
+      "cache+lockfile+node_modules",
+      "lockfile",
+      "lockfile+node_modules",
+    ]
+  ).filter((v) => dataSource[v as Variation]);
+
+  const packageManagers =
+    options?.packageManagers ?? chartData.chartData.packageManagers;
 
   // Group data by fixture
   const fixtureGroups: Record<string, FixtureResult[]> = {};
 
-  packageManagementVariations.forEach((variation) => {
+  variationNames.forEach((variation) => {
     const variationData = dataSource[variation as Variation];
     if (!variationData) return;
 
@@ -79,7 +93,6 @@ export const calculateAverageVariationData = (
   const averagedResults: FixtureResult[] = [];
 
   Object.entries(fixtureGroups).forEach(([fixture, results]) => {
-    const packageManagers = chartData.chartData.packageManagers;
     const averagedResult: FixtureResult = { fixture: fixture as Fixture };
 
     packageManagers.forEach((pm: PackageManager) => {
@@ -154,13 +167,18 @@ export const getVariationCategories = (
     "lockfile+node_modules",
   ].filter((v) => variations.includes(v as Variation)) as Variation[];
 
-  const taskExecutionVariations = ["build", "build-cache", "run"].filter((v) =>
-    variations.includes(v as Variation),
-  ) as Variation[];
+  const taskExecutionVariations = [
+    "average",
+    "build",
+    "build-cache",
+    "run",
+  ].filter((v) => variations.includes(v as Variation)) as Variation[];
 
-  const registryVariations = ["registry-clean", "registry-lockfile"].filter(
-    (v) => variations.includes(v as Variation),
-  ) as Variation[];
+  const registryVariations = [
+    "average",
+    "registry-clean",
+    "registry-lockfile",
+  ].filter((v) => variations.includes(v as Variation)) as Variation[];
 
   const categories: VariationCategory[] = [];
 

--- a/app/src/routes.tsx
+++ b/app/src/routes.tsx
@@ -17,7 +17,7 @@ const packageManagerRoutes: RouteObject = {
 const taskRunnerRoutes: RouteObject = {
   path: "task-runners",
   children: [
-    { index: true, element: <Navigate to="build" replace={true} /> },
+    { index: true, element: <Navigate to="average" replace={true} /> },
     { path: ":variation", element: <VariationPage /> },
     { path: ":variation/:section", element: <VariationPage /> },
     { path: ":variation/:section/:fixture", element: <VariationPage /> },
@@ -29,7 +29,7 @@ const registryRoutes: RouteObject = {
   children: [
     {
       index: true,
-      element: <Navigate to="registry-clean" replace={true} />,
+      element: <Navigate to="average" replace={true} />,
     },
     { path: ":variation", element: <VariationPage /> },
     { path: ":variation/:section", element: <VariationPage /> },

--- a/app/src/types/chart-data.ts
+++ b/app/src/types/chart-data.ts
@@ -184,6 +184,10 @@ export interface BenchmarkChartData {
   registryChartData?: ChartDataSet;
   registryPerPackageCountChartData?: ChartDataSet;
   versions?: PackageManagerVersions;
+  taskRunnerAverageData?: FixtureResult[];
+  taskRunnerAveragePerPackageData?: FixtureResult[];
+  registryAverageData?: FixtureResult[];
+  registryAveragePerPackageData?: FixtureResult[];
 }
 
 export interface PackageCountEntry {


### PR DESCRIPTION
## Summary

Add an `average` variation to the **task runners** and **registries** sections, matching the existing package managers average behavior. Each section now defaults to showing the average across its variations as the landing view.

### Changes

- **`app/src/lib/utils.ts`**: Generalized `calculateAverageVariationData()` to accept an `options` parameter with custom variation names, data sources, and package manager lists. Added `"average"` to the task execution and registry variation category lists in `getVariationCategories()`.

- **`app/src/hooks/use-chart-data.ts`**: Calculate task runner average (across `build`, `build-cache`, `run`) and registry average (across `registry-clean`, `registry-lockfile`) using the appropriate data sources and package managers. Store route-specific averages on `BenchmarkChartData`.

- **`app/src/types/chart-data.ts`**: Added `taskRunnerAverageData`, `taskRunnerAveragePerPackageData`, `registryAverageData`, and `registryAveragePerPackageData` fields to `BenchmarkChartData`.

- **`app/src/components/variation/index.tsx`**: Made `VariationPage` route-aware — when the variation is `"average"`, selects the correct data based on the current route (`package-managers`, `task-runners`, or `registries`).

- **`app/src/routes.tsx`**: Updated default routes for task runners (`"build"` → `"average"`) and registries (`"registry-clean"` → `"average"`).

### Build
```
✅ tsc -b passes
✅ vite build passes
✅ eslint passes
```

Co-authored-by: Darcy Clarke <darcy@vlt.sh>