### PR TITLE
fix: pass route context to chart/table components for average variation

### DIFF
--- a/app/src/components/history-chart.tsx
+++ b/app/src/components/history-chart.tsx
@@ -49,6 +49,10 @@ interface HistoryChartProps {
   colors: ColorMap;
   packageManagers: PackageManager[];
   chartData: BenchmarkChartData;
+  /** Override registry detection (e.g. for "average" variation on registry route) */
+  isRegistryRoute?: boolean;
+  /** Override task-execution detection (e.g. for "average" variation on task-runner route) */
+  isTaskExecutionRoute?: boolean;
 }
 
 export const HistoryChart = ({
@@ -57,14 +61,16 @@ export const HistoryChart = ({
   colors,
   packageManagers,
   chartData,
+  isRegistryRoute,
+  isTaskExecutionRoute,
 }: HistoryChartProps) => {
   const { theme } = useTheme();
   const resolvedTheme = resolveTheme(theme);
   const { enabledPackageManagers } = usePackageManagerFilter();
   const isMobile = useMediaQuery("(max-width: 767px)");
   const [range, setRange] = useState<number>(90);
-  const isRegistry = isRegistryVariation(currentVariation);
-  const isTaskExecution = isTaskExecutionVariation(currentVariation);
+  const isRegistry = isRegistryRoute ?? isRegistryVariation(currentVariation);
+  const isTaskExecution = isTaskExecutionRoute ?? isTaskExecutionVariation(currentVariation);
   // Package-management variations now use per-package data (ms/pkg);
   // registry and task-runner variations still use total time (seconds).
   const isPerPackageVariation = !isRegistry && !isTaskExecution;

--- a/app/src/components/variation/chart.tsx
+++ b/app/src/components/variation/chart.tsx
@@ -170,6 +170,10 @@ interface VariationChartProps {
   chartData: BenchmarkChartData;
   isPerPackage: boolean;
   currentVariation: string;
+  /** Override registry detection (e.g. for "average" variation on registry route) */
+  isRegistryRoute?: boolean;
+  /** Override task-execution detection (e.g. for "average" variation on task-runner route) */
+  isTaskExecutionRoute?: boolean;
 }
 
 export const VariationChart = ({
@@ -180,11 +184,13 @@ export const VariationChart = ({
   chartData,
   isPerPackage,
   currentVariation,
+  isRegistryRoute,
+  isTaskExecutionRoute,
 }: VariationChartProps) => {
   const { theme } = useTheme();
   const { enabledPackageManagers } = usePackageManagerFilter();
   const { getYAxisDomain } = useYAxis();
-  const isRegistry = isRegistryVariation(currentVariation);
+  const isRegistry = isRegistryRoute ?? isRegistryVariation(currentVariation);
 
   // Filter package managers based on global filter
   const filteredPackageManagers = useMemo(
@@ -275,7 +281,8 @@ export const VariationChart = ({
     resolvedTheme,
   ]);
 
-  const yAxisLabel = isTaskExecutionVariation(currentVariation)
+  const isTaskExecution = isTaskExecutionRoute ?? isTaskExecutionVariation(currentVariation);
+  const yAxisLabel = isTaskExecution
     ? "Time (seconds)"
     : isPerPackage
       ? "Time (ms per package)"
@@ -417,8 +424,7 @@ export const VariationChart = ({
 
   const isMobile = useMediaQuery("(max-width: 767px)");
 
-  const isTaskOrRegistry =
-    isTaskExecutionVariation(currentVariation) || isRegistryVariation(currentVariation);
+  const isTaskOrRegistry = isTaskExecution || isRegistry;
 
   if (!isPerPackage && isTaskOrRegistry) {
     // Task runners & registries: horizontal bar charts per fixture, sorted by speed

--- a/app/src/components/variation/index.tsx
+++ b/app/src/components/variation/index.tsx
@@ -227,6 +227,8 @@ export const VariationPage = () => {
           colors={colors}
           packageManagers={packageManagers}
           chartData={chartData}
+          isRegistryRoute={isRegistry}
+          isTaskExecutionRoute={isTaskExecution}
         />
       )}
 
@@ -240,6 +242,8 @@ export const VariationPage = () => {
           chartData={chartData}
           isPerPackage={false}
           currentVariation={variation}
+          isRegistryRoute={isRegistry}
+          isTaskExecutionRoute={isTaskExecution}
         />
       </div>
 
@@ -254,6 +258,8 @@ export const VariationPage = () => {
             chartData={chartData}
             isPerPackage={true}
             currentVariation={variation as string}
+            isRegistryRoute={isRegistry}
+            isTaskExecutionRoute={isTaskExecution}
           />
         </div>
       ) : null}
@@ -269,6 +275,7 @@ export const VariationPage = () => {
               chartData={chartData}
               isPerPackage={true}
               currentVariation={variation as string}
+              isRegistryRoute={isRegistry}
             />
           </div>
         ) : null}
@@ -291,6 +298,7 @@ export const VariationPage = () => {
               packageManagers={packageCountPackageManagers}
               versions={chartData.versions}
               currentVariation={variation as string}
+              isRegistryRoute={isRegistry}
             />
           </div>
         ) : null}
@@ -313,6 +321,7 @@ export const VariationPage = () => {
               packageManagers={processCountPackageManagers}
               versions={chartData.versions}
               currentVariation={variation as string}
+              isRegistryRoute={isRegistry}
             />
           </div>
         ) : null}
@@ -328,6 +337,7 @@ export const VariationPage = () => {
             chartData={chartData}
             isPerPackage={false}
             currentVariation={variation}
+            isRegistryRoute={isRegistry}
           />
         </div>
       </div>

--- a/app/src/components/variation/package-count-table.tsx
+++ b/app/src/components/variation/package-count-table.tsx
@@ -44,6 +44,8 @@ interface PackageCountTableProps {
   packageManagers: PackageManager[];
   versions?: PackageManagerVersions;
   currentVariation: string;
+  /** Override registry detection (e.g. for "average" variation on registry route) */
+  isRegistryRoute?: boolean;
 }
 
 interface TransposedPackageCountRow {
@@ -60,10 +62,11 @@ export const PackageCountTable = ({
   packageManagers,
   versions,
   currentVariation,
+  isRegistryRoute,
 }: PackageCountTableProps) => {
   const { enabledPackageManagers } = usePackageManagerFilter();
   const [sorting, setSorting] = useState<SortingState>([]);
-  const isRegistry = isRegistryVariation(currentVariation);
+  const isRegistry = isRegistryRoute ?? isRegistryVariation(currentVariation);
   const showVersions = !isRegistry;
 
   // Filter package managers based on global filter

--- a/app/src/components/variation/process-count-table.tsx
+++ b/app/src/components/variation/process-count-table.tsx
@@ -43,6 +43,8 @@ interface ProcessCountTableProps {
   packageManagers: PackageManager[];
   versions?: PackageManagerVersions;
   currentVariation: string;
+  /** Override registry detection (e.g. for "average" variation on registry route) */
+  isRegistryRoute?: boolean;
 }
 
 interface TransposedProcessCountRow {
@@ -59,10 +61,11 @@ export const ProcessCountTable = ({
   packageManagers,
   versions,
   currentVariation,
+  isRegistryRoute,
 }: ProcessCountTableProps) => {
   const { enabledPackageManagers } = usePackageManagerFilter();
   const [sorting, setSorting] = useState<SortingState>([]);
-  const isRegistry = isRegistryVariation(currentVariation);
+  const isRegistry = isRegistryRoute ?? isRegistryVariation(currentVariation);
   const showVersions = !isRegistry;
 
   // Filter package managers based on global filter

--- a/app/src/components/variation/table.tsx
+++ b/app/src/components/variation/table.tsx
@@ -45,6 +45,8 @@ interface VariationTableProps {
   chartData: BenchmarkChartData;
   isPerPackage: boolean;
   currentVariation: string;
+  /** Override registry detection (e.g. for "average" variation on registry route) */
+  isRegistryRoute?: boolean;
 }
 
 interface TransposedVariationRow {
@@ -63,10 +65,11 @@ export const VariationTable = ({
   chartData,
   isPerPackage,
   currentVariation,
+  isRegistryRoute,
 }: VariationTableProps) => {
   const { enabledPackageManagers } = usePackageManagerFilter();
   const [sorting, setSorting] = useState<SortingState>([]);
-  const isRegistry = isRegistryVariation(currentVariation);
+  const isRegistry = isRegistryRoute ?? isRegistryVariation(currentVariation);
   const showVersions = !isRegistry;
 
   // Filter package managers based on global filter


### PR DESCRIPTION
## Problem

When PR #133 added the `average` variation for registries and task runners, the **data** was correctly computed and selected per-route in the `VariationPage` component. However, the child rendering components (`VariationChart`, `VariationTable`, `HistoryChart`, `PackageCountTable`, `ProcessCountTable`) independently determined whether they were in a registry or task-runner context by checking only the variation name via `isRegistryVariation(currentVariation)` and `isTaskExecutionVariation(currentVariation)` — both of which return `false` for `"average"`.

This caused the registries and task-runners average pages to render with **package-manager formatting**:
- Grouped bar charts instead of horizontal per-fixture bars (the registry/task-runner layout)
- PM display names (e.g. "npm") instead of registry hostnames (e.g. "registry.npmjs.org")
- Version strings shown where they should be hidden (registries)
- No baseline highlighting for npm on registry pages
- Wrong Y-axis labels

## Fix

Add optional `isRegistryRoute` / `isTaskExecutionRoute` props to all affected components. `VariationPage` already correctly derives these flags from the URL route context — now it passes them down so child components use route-aware detection instead of variation-name-only checks. The props use the `??  (nullish coalescing) pattern so existing callers are unaffected — the route override is only applied when explicitly provided.

## Files changed

- `app/src/components/variation/index.tsx` — pass `isRegistryRoute` / `isTaskExecutionRoute` to all child components
- `app/src/components/variation/chart.tsx` — accept and use route-aware props for layout, labels, and display names
- `app/src/components/variation/table.tsx` — accept and use route-aware `isRegistryRoute`
- `app/src/components/variation/package-count-table.tsx` — accept and use route-aware `isRegistryRoute`
- `app/src/components/variation/process-count-table.tsx` — accept and use route-aware `isRegistryRoute`
- `app/src/components/history-chart.tsx` — accept and use route-aware props for unit labels and formatting

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>