### PR TITLE
fix: show correct history chart data for registry/task-runner averages

### DIFF
--- a/app/src/components/history-chart.tsx
+++ b/app/src/components/history-chart.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/ui/button";
 import { resolveTheme, useTheme } from "@/components/theme-provider";
 import { usePackageManagerFilter } from "@/contexts/package-manager-filter-context";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import { formatPackageManagerLabel, isRegistryVariation, isTaskExecutionVariation } from "@/lib/utils";
+import { formatPackageManagerLabel, isAverageVariation, isRegistryVariation, isTaskExecutionVariation } from "@/lib/utils";
 import { TrendingUp } from "lucide-react";
 import { format, parseISO } from "date-fns";
 
@@ -75,7 +75,16 @@ export const HistoryChart = ({
   // registry and task-runner variations still use total time (seconds).
   const isPerPackageVariation = !isRegistry && !isTaskExecution;
 
-  const variationData = historyData.variations[currentVariation];
+  // For the "average" variation, look up the route-specific synthetic
+  // average so registries and task-runners don't show PM averages.
+  const isAverage = isAverageVariation(currentVariation);
+  const variationKey =
+    isAverage && isRegistry
+      ? "registryAverage"
+      : isAverage && isTaskExecution
+        ? "taskRunnerAverage"
+        : currentVariation;
+  const variationData = historyData.variations[variationKey];
 
   // Merge PMs from the current chart data with PMs that only exist in
   // historical data (e.g. cloudsmith).  This ensures discontinued PMs

--- a/app/src/hooks/use-history-data.ts
+++ b/app/src/hooks/use-history-data.ts
@@ -246,29 +246,22 @@ export const useHistoryData = (): UseHistoryDataReturn => {
           }
         }
 
-        // Compute synthetic "average" variation from package management variations
-        const PM_VARIATIONS = [
-          "clean",
-          "node_modules",
-          "cache",
-          "cache+node_modules",
-          "cache+lockfile",
-          "cache+lockfile+node_modules",
-          "lockfile",
-          "lockfile+node_modules",
-        ];
-        const presentPmVariations = PM_VARIATIONS.filter(
-          (v) => variations[v],
-        );
+        // Compute synthetic average variations by averaging across
+        // the constituent variations in each category.
+        const computeSyntheticAverage = (
+          key: string,
+          sourceVariations: string[],
+        ) => {
+          const present = sourceVariations.filter((v) => variations[v]);
+          if (present.length === 0) return;
 
-        if (presentPmVariations.length > 0) {
           const avgSeries: HistoryVariation = {};
           for (const pm of PACKAGE_MANAGERS) {
             avgSeries[pm] = [];
             for (let i = 0; i < dates.length; i++) {
               let sum = 0;
               let count = 0;
-              for (const v of presentPmVariations) {
+              for (const v of present) {
                 const val = variations[v][pm]?.[i];
                 if (val !== null && val !== undefined) {
                   sum += val;
@@ -280,8 +273,33 @@ export const useHistoryData = (): UseHistoryDataReturn => {
               );
             }
           }
-          variations["average"] = avgSeries;
-        }
+          variations[key] = avgSeries;
+        };
+
+        // Package management average
+        computeSyntheticAverage("average", [
+          "clean",
+          "node_modules",
+          "cache",
+          "cache+node_modules",
+          "cache+lockfile",
+          "cache+lockfile+node_modules",
+          "lockfile",
+          "lockfile+node_modules",
+        ]);
+
+        // Registry average
+        computeSyntheticAverage("registryAverage", [
+          "registry-clean",
+          "registry-lockfile",
+        ]);
+
+        // Task-runner average
+        computeSyntheticAverage("taskRunnerAverage", [
+          "build",
+          "build-cache",
+          "run",
+        ]);
 
         setHistoryData({ dates, variations });
       } catch (e) {


### PR DESCRIPTION
## Summary

The **Performance Over Time** history chart was showing package manager average data on the registry and task-runner average pages. While PR #134 fixed the bar charts by passing `isRegistryRoute`/`isTaskExecutionRoute` props, the underlying history data was still using the PM-only synthetic average.

## Problem

When visiting `/registries/average` or `/task-runners/average`, the history chart looked up `historyData.variations["average"]` which was always computed from package management variations (`clean`, `cache`, `lockfile`, etc.). This meant the line graph showed PM average performance instead of registry/task-runner average performance.

## Changes

### `app/src/hooks/use-history-data.ts`
- Extracted the synthetic average computation into a reusable `computeSyntheticAverage` helper
- Now computes three synthetic average keys:
  - `"average"` — from PM variations (`clean`, `node_modules`, `cache`, etc.)
  - `"registryAverage"` — from registry variations (`registry-clean`, `registry-lockfile`)
  - `"taskRunnerAverage"` — from task-runner variations (`build`, `build-cache`, `run`)

### `app/src/components/history-chart.tsx`
- When on the `average` variation with `isRegistryRoute`, looks up `"registryAverage"` instead of `"average"`
- When on the `average` variation with `isTaskExecutionRoute`, looks up `"taskRunnerAverage"` instead of `"average"`
- Package manager average page continues to use `"average"` as before

## Testing

The fix ensures each average page's history chart matches its bar chart data source:
- **PM average page** → history from PM variations ✅ (unchanged)
- **Registry average page** → history from registry variations ✅ (fixed)
- **Task-runner average page** → history from task-runner variations ✅ (fixed)

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>