### PR TITLE
fix: update chart colors for GitHub and Cloudsmith

### DIFF
--- a/app/src/components/header.tsx
+++ b/app/src/components/header.tsx
@@ -341,7 +341,7 @@ const LeaderBoardItem = ({
               size={28}
               className={cn(
                 packageManager === "vlt" && "dark:text-white",
-                packageManager === "github" && "text-[#6336b8]",
+                packageManager === "github" && "text-[#8250DF]",
               )}
             />
           )}

--- a/app/src/components/history-chart.tsx
+++ b/app/src/components/history-chart.tsx
@@ -39,7 +39,7 @@ const RANGE_OPTIONS = [
  * (e.g. cloudsmith was removed from active benchmarks but old results remain).
  */
 const HISTORY_FALLBACK_COLORS: Partial<Record<PackageManager, string>> = {
-  cloudsmith: "#2C5BB4",
+  cloudsmith: "#2a6fe1",
   jfrog: "#40BE46",
 };
 

--- a/app/src/components/icons/cloudsmith.tsx
+++ b/app/src/components/icons/cloudsmith.tsx
@@ -5,7 +5,7 @@ export const Cloudsmith = createLucideIcon("Cloudsmith", [
     "path",
     {
       d: "m23.99 10.67v2.67l-10.66 10.66h-2.67l-10.66-10.66v-2.67l10.66-10.66h2.67zm-5.74 1.33c0-3.46-2.80-6.26-6.26-6.26-3.46 0-6.26 2.80-6.26 6.26 0 3.46 2.80 6.26 6.26 6.26 3.46 0 6.26-2.80 6.26-6.26z",
-      fill: "#2C5BB4",
+      fill: "#2a6fe1",
       fillRule: "evenodd",
       key: "1",
       strokeWidth: "0",

--- a/scripts/generate-chart.js
+++ b/scripts/generate-chart.js
@@ -46,8 +46,8 @@ const REGISTRY_COLORS = {
   npm: "#cb0606",
   vlt: "#000000",
   aws: "#ff9900",
-  cloudsmith: "#2C5BB4",
-  github: "#6336b8",
+  cloudsmith: "#2a6fe1",
+  github: "#8250DF",
   jfrog: "#40BE46",
 };
 


### PR DESCRIPTION
## Summary

Updates two colors used in the benchmark charts:

- **GitHub branch color**: `#6336b8` → `#8250DF` (brighter purple)
- **Cloudsmith blue**: `#2C5BB4` → `#2a6fe1`

### Files changed

| File | Change |
|------|--------|
| `scripts/generate-chart.js` | Updated `REGISTRY_COLORS` for both cloudsmith and github |
| `app/src/components/header.tsx` | Updated Tailwind `text-[]` color for github leaderboard item |
| `app/src/components/icons/cloudsmith.tsx` | Updated SVG fill color |
| `app/src/components/history-chart.tsx` | Updated fallback color for cloudsmith in history charts |

Co-authored-by: Darcy Clarke <darcy@darcyclarke.me>