### PR TITLE
ci: bump benchmark job timeout from 90 to 120 minutes

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: [detect-changes]
     if: needs.detect-changes.outputs.app_only != 'true'
-    timeout-minutes: 90
+    timeout-minutes: 120
     environment: Benchmark
     strategy:
       fail-fast: false


### PR DESCRIPTION
The `babylon, registry-clean` job needs ~100 min total wall time (6 registries × warmup + 3 runs each), exceeding the current 90-min limit. This caused [run #30658887224](https://github.com/vltpkg/benchmarks/actions/runs/30658887224) to time out on both attempts.

Bumps the benchmark job `timeout-minutes` from 90 → 120, giving ~20 min of headroom.

Co-authored-by: @lukekarrys