### PR TITLE
ci: reprocess workflow to redeploy a run's results under an explicit date

### DIFF
--- a/.github/workflows/reprocess.yml
+++ b/.github/workflows/reprocess.yml
@@ -1,0 +1,83 @@
+name: Reprocess Benchmark Results
+
+# Re-runs process + deploy from an EXISTING benchmark run's artifacts, writing
+# the results to an explicit date folder. Use case: a run whose process step
+# crossed UTC midnight and stamped the wrong date. The date input must match
+# the calendar day the run's benchmark jobs actually executed.
+#
+# Artifacts are retained for 7 days, so this only works on recent runs.
+on:
+  workflow_dispatch:
+    inputs:
+      run-id:
+        description: "The benchmark workflow run ID whose artifacts to reprocess"
+        required: true
+      date:
+        description: "Date folder to write (YYYY-MM-DD; the day the benchmarks ran)"
+        required: true
+
+jobs:
+  reprocess:
+    name: "Reprocess & Deploy"
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - name: Download Results
+        uses: actions/download-artifact@v8
+        with:
+          path: results
+          pattern: results-*
+          run-id: ${{ inputs.run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download Versions
+        uses: actions/download-artifact@v8
+        with:
+          path: versions-temp
+          pattern: versions-*
+          run-id: ${{ inputs.run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Process Results
+        env:
+          BENCH_DATE: ${{ inputs.date }}
+        run: |
+          ./bench process
+      - name: Summarize results in log
+        run: |
+          {
+            echo '```'
+            for f in results/results-*/benchmarks.json; do
+              [ -f "$f" ] || continue
+              node -e '
+                const fs = require("fs")
+                const p = process.argv[1]
+                const name = p.split("/")[1].replace(/^results-/, "")
+                for (const r of JSON.parse(fs.readFileSync(p, "utf8")).results ?? []) {
+                  const times = (r.times ?? []).map((t) => t.toFixed(1)).join(", ")
+                  console.log(`${name}  ${r.command}: mean=${(r.mean ?? 0).toFixed(1)}s times=[${times}]`)
+                }
+              ' "$f"
+            done
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: Install vlt
+        run: |
+          npm install -g vlt@latest
+      - name: Build Charts View
+        run: |
+          pushd app
+          vlt install
+          vlt run build
+          popd
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: results
+          keep_files: true

--- a/.github/workflows/reprocess.yml
+++ b/.github/workflows/reprocess.yml
@@ -48,24 +48,6 @@ jobs:
           BENCH_DATE: ${{ inputs.date }}
         run: |
           ./bench process
-      - name: Summarize results in log
-        run: |
-          {
-            echo '```'
-            for f in results/results-*/benchmarks.json; do
-              [ -f "$f" ] || continue
-              node -e '
-                const fs = require("fs")
-                const p = process.argv[1]
-                const name = p.split("/")[1].replace(/^results-/, "")
-                for (const r of JSON.parse(fs.readFileSync(p, "utf8")).results ?? []) {
-                  const times = (r.times ?? []).map((t) => t.toFixed(1)).join(", ")
-                  console.log(`${name}  ${r.command}: mean=${(r.mean ?? 0).toFixed(1)}s times=[${times}]`)
-                }
-              ' "$f"
-            done
-            echo '```'
-          } | tee -a "$GITHUB_STEP_SUMMARY"
       - name: Install vlt
         run: |
           npm install -g vlt@latest

--- a/.github/workflows/reprocess.yml
+++ b/.github/workflows/reprocess.yml
@@ -63,3 +63,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: results
           keep_files: true
+          full_commit_message: "reprocess: run ${{ inputs.run-id }} -> ${{ inputs.date }} (dispatched via ${{ github.workflow }} run ${{ github.run_id }})"

--- a/scripts/process-results.sh
+++ b/scripts/process-results.sh
@@ -2,7 +2,8 @@
 set -Eeuxo pipefail
 
 # Get current date for results directory
-DATE=$(date +%Y-%m-%d)
+# BENCH_DATE overrides the folder date (see .github/workflows/reprocess.yml)
+DATE=${BENCH_DATE:-$(date +%Y-%m-%d)}
 
 # Create results directory structure
 mkdir -p "results/$DATE"


### PR DESCRIPTION
Adds a dispatch-only `reprocess.yml` workflow that re-runs process + deploy from an existing benchmark run's artifacts and writes the output to an explicit date folder, plus a one-line `BENCH_DATE` override in `process-results.sh` (defaults to today, so normal runs are unaffected).

Motivation: tonight's full run (31644732609) executed entirely on 2026-08-12 but its process step started at 23:59:45 UTC and date-stamped the output 2026-08-13, leaving the day's regression data in place on the charts. Hand-fixing gh-pages data turned out to be error-prone because each date folder mixes measurement copies with generator-derived files (chart-data.json has four sections, and the history chart reads one of them) — a partial hand-merge left stale derived data twice. This workflow makes the correction reproducible: same artifacts, same generator, CI-authored commit, full paper trail in Actions.

Usage: `gh workflow run reprocess.yml -f run-id=<benchmark run id> -f date=<YYYY-MM-DD>`. The date must be the calendar day the run's benchmark jobs executed; artifacts are retained 7 days so this only works on recent runs. The deploy uses the same `keep_files` publish as the daily run, so the target date folder's files are wholesale overwritten with single-provenance output.

Immediate plan after merge: rewrite gh-pages to drop the three hand-fix commits (dc5f3dce, abc9f737, 27ec2d0e), then dispatch with run-id=31644732609 date=2026-08-12 so the evening run's complete results replace the morning's regression data with pipeline provenance.
