### PR TITLE
fix: allow aube install scripts with npm 12

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -57,12 +57,12 @@ npm install -g vite-plus@latest
 npm install --global pnpm@next-12 --prefix /tmp/pnpm12 --allow-scripts=pnpm
 
 # Install aube via npm (available as the `@endevco/aube` package).
-# npm 12 blocks aube's preinstall script, which selects and installs its
-# platform-specific native binary. Bootstrap it with npm 11 until aube's npm
-# package supports npm 12's default-deny lifecycle policy.
+# npm 12 blocks dependency lifecycle scripts by default, but aube's preinstall
+# selects and installs its platform-specific native binary. Allow only aube's
+# installer so the binary is available to the benchmark matrix.
 # Non-fatal: aube may not have a working binary for all platforms (e.g. arm64).
 # If it fails to install, the benchmark suite continues without aube.
-if ! npx --yes npm@11 install -g @endevco/aube@latest; then
+if ! npm install -g --allow-scripts=@endevco/aube @endevco/aube@latest; then
   echo "Warning: aube installation failed (may not support this platform) — skipping aube benchmarks"
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -57,9 +57,12 @@ npm install -g vite-plus@latest
 npm install --global pnpm@next-12 --prefix /tmp/pnpm12 --allow-scripts=pnpm
 
 # Install aube via npm (available as the `@endevco/aube` package).
+# npm 12 blocks aube's preinstall script, which selects and installs its
+# platform-specific native binary. Bootstrap it with npm 11 until aube's npm
+# package supports npm 12's default-deny lifecycle policy.
 # Non-fatal: aube may not have a working binary for all platforms (e.g. arm64).
 # If it fails to install, the benchmark suite continues without aube.
-if ! npm install -g @endevco/aube@latest; then
+if ! npx --yes npm@11 install -g @endevco/aube@latest; then
   echo "Warning: aube installation failed (may not support this platform) — skipping aube benchmarks"
 fi
 


### PR DESCRIPTION
## Summary

- allowlist `@endevco/aube` when the benchmark setup installs it with npm 12
- restore Aube to the benchmark matrix without downgrading the bootstrap package manager

## Root cause

npm 12 blocks dependency lifecycle scripts by default. `@endevco/aube` uses a preinstall script to select and install its platform-specific native binary, so the existing plain global install completed without creating an `aube` executable and the benchmark harness excluded it.

Aube 1.41.0 now supports npm 12's allowlist propagation correctly. Explicitly allowing only `@endevco/aube` lets its required installer run while retaining npm 12's default-deny policy for other packages.

@darcyclarke could you take a look?

## Validation

- `bash -n scripts/setup.sh`
- `shellcheck scripts/setup.sh`
- installed `@endevco/aube@latest` into an isolated prefix with npm 12.0.2 and `--allow-scripts=@endevco/aube`
- verified the installed binary reports Aube 1.41.0

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*