### PR TITLE
Fix task runner tools not appearing in Tools toggle menu

### DIFF
--- a/app/src/components/header.tsx
+++ b/app/src/components/header.tsx
@@ -20,6 +20,7 @@ import {
   getVariationCategories,
   getPackageManagerDisplayName,
   isBaselinePackageManager,
+  isAverageVariation,
   sortVariations,
 } from "@/lib/utils";
 import type { LeaderboardRoute } from "@/lib/utils";
@@ -100,8 +101,14 @@ const HeaderNavigation = forwardRef<HTMLDivElement, ComponentProps<"div">>(
   ({ className, ...props }, ref) => {
     const { chartData, location, currentVariation, sortedVariations } =
       useHeaderContext();
+    const baseRoute = location.pathname.split("/")[1];
+    const isAverage = isAverageVariation(currentVariation as string);
     const variationData = chartData
-      ? chartData.chartData.data[currentVariation as Variation] || []
+      ? isAverage && baseRoute === "task-runners"
+        ? (chartData.taskRunnerAverageData ?? [])
+        : isAverage && baseRoute === "registries"
+          ? (chartData.registryAverageData ?? [])
+          : chartData.chartData.data[currentVariation as Variation] || []
       : [];
     const fixtures = useMemo(
       () => getAvailableFixtures(variationData),


### PR DESCRIPTION
## Problem

On the benchmarks page at `benchmarks.vlt.sh/#/task-runners/average`, the Tools filter menu only shows package manager tools — it doesn't include the 3 task-runner-specific tools (nx, turbo, vp). These tools appear in the charts but users cannot toggle them on/off via the Tools dropdown.

## Root Cause

In `app/src/components/header.tsx`, the `HeaderNavigation` component computes `variationData` using `chartData.chartData.data[currentVariation]` unconditionally. However, when on the `task-runners` route with the "average" variation, the actual data comes from `chartData.taskRunnerAverageData` (not `chartData.chartData.data["average"]`). Similarly for registries, the data comes from `chartData.registryAverageData`.

The `VariationPage` component already handles this correctly with route-aware conditionals, but the header was missing this logic.

## Fix

Made the `variationData` computation in `HeaderNavigation` route-aware:

- When `baseRoute === "task-runners"` and variation is "average", use `chartData.taskRunnerAverageData`
- When `baseRoute === "registries"` and variation is "average", use `chartData.registryAverageData`
- Otherwise, use `chartData.chartData.data[currentVariation]` (existing behavior)

This matches the logic already used in `VariationPage` (`app/src/components/variation/index.tsx`).

Fixes vltpkg/vlt.io#1942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Header navigation now displays task runner and registry data correctly for average variations.
  * Other variations continue to use their standard data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->